### PR TITLE
Update gemini model name

### DIFF
--- a/examples/black_box_demo.ipynb
+++ b/examples/black_box_demo.ipynb
@@ -224,7 +224,7 @@
     "# !{sys.executable} -m pip install langchain-google-vertexai\n",
     "from langchain_google_vertexai import ChatVertexAI\n",
     "\n",
-    "llm = ChatVertexAI(model=\"gemini-pro\")"
+    "llm = ChatVertexAI(model=\"gemini-1.5-flash\")"
    ]
   },
   {
@@ -1021,9 +1021,9 @@
  "metadata": {
   "environment": {
    "kernel": "uqlm",
-   "name": "workbench-notebooks.m126",
+   "name": "workbench-notebooks.m125",
    "type": "gcloud",
-   "uri": "us-docker.pkg.dev/deeplearning-platform-release/gcr.io/workbench-notebooks:m126"
+   "uri": "us-docker.pkg.dev/deeplearning-platform-release/gcr.io/workbench-notebooks:m125"
   },
   "kernelspec": {
    "display_name": "uqlm",

--- a/examples/ensemble_off_the_shelf_demo.ipynb
+++ b/examples/ensemble_off_the_shelf_demo.ipynb
@@ -219,7 +219,7 @@
     "# !{sys.executable} -m pip install langchain-google-vertexai\n",
     "from langchain_google_vertexai import ChatVertexAI\n",
     "\n",
-    "llm = ChatVertexAI(model=\"gemini-pro\")"
+    "llm = ChatVertexAI(model=\"gemini-1.5-flash\")"
    ]
   },
   {
@@ -891,9 +891,9 @@
  "metadata": {
   "environment": {
    "kernel": "uqlm",
-   "name": "workbench-notebooks.m126",
+   "name": "workbench-notebooks.m125",
    "type": "gcloud",
-   "uri": "us-docker.pkg.dev/deeplearning-platform-release/gcr.io/workbench-notebooks:m126"
+   "uri": "us-docker.pkg.dev/deeplearning-platform-release/gcr.io/workbench-notebooks:m125"
   },
   "kernelspec": {
    "display_name": "uqlm",

--- a/examples/ensemble_tuning_demo.ipynb
+++ b/examples/ensemble_tuning_demo.ipynb
@@ -278,7 +278,7 @@
     "# !{sys.executable} -m pip install langchain-google-vertexai\n",
     "from langchain_google_vertexai import ChatVertexAI\n",
     "\n",
-    "gemini = ChatVertexAI(model=\"gemini-pro\")"
+    "gemini = ChatVertexAI(model=\"gemini-1.5-flash\")"
    ]
   },
   {
@@ -1241,9 +1241,9 @@
  "metadata": {
   "environment": {
    "kernel": "uqlm",
-   "name": "workbench-notebooks.m126",
+   "name": "workbench-notebooks.m125",
    "type": "gcloud",
-   "uri": "us-docker.pkg.dev/deeplearning-platform-release/gcr.io/workbench-notebooks:m126"
+   "uri": "us-docker.pkg.dev/deeplearning-platform-release/gcr.io/workbench-notebooks:m125"
   },
   "kernelspec": {
    "display_name": "uqlm",

--- a/examples/judges_demo.ipynb
+++ b/examples/judges_demo.ipynb
@@ -244,7 +244,7 @@
     "# !{sys.executable} -m pip install langchain-google-vertexai\n",
     "from langchain_google_vertexai import ChatVertexAI\n",
     "\n",
-    "gemini_pro = ChatVertexAI(model_name=\"gemini-pro\")\n",
+    "gemini_pro = ChatVertexAI(model_name=\"gemini-1.5-pro\")\n",
     "gemini_flash = ChatVertexAI(model_name=\"gemini-1.5-flash\")"
    ]
   },
@@ -876,9 +876,9 @@
  "metadata": {
   "environment": {
    "kernel": "uqlm",
-   "name": "workbench-notebooks.m126",
+   "name": "workbench-notebooks.m125",
    "type": "gcloud",
-   "uri": "us-docker.pkg.dev/deeplearning-platform-release/gcr.io/workbench-notebooks:m126"
+   "uri": "us-docker.pkg.dev/deeplearning-platform-release/gcr.io/workbench-notebooks:m125"
   },
   "kernelspec": {
    "display_name": "uqlm",

--- a/examples/semantic_entropy_demo.ipynb
+++ b/examples/semantic_entropy_demo.ipynb
@@ -215,7 +215,7 @@
     "# !{sys.executable} -m pip install langchain-google-vertexai\n",
     "from langchain_google_vertexai import ChatVertexAI\n",
     "\n",
-    "llm = ChatVertexAI(model=\"gemini-pro\")"
+    "llm = ChatVertexAI(model=\"gemini-1.5-flash\")"
    ]
   },
   {
@@ -871,9 +871,9 @@
  "metadata": {
   "environment": {
    "kernel": "uqlm",
-   "name": "workbench-notebooks.m126",
+   "name": "workbench-notebooks.m125",
    "type": "gcloud",
-   "uri": "us-docker.pkg.dev/deeplearning-platform-release/gcr.io/workbench-notebooks:m126"
+   "uri": "us-docker.pkg.dev/deeplearning-platform-release/gcr.io/workbench-notebooks:m125"
   },
   "kernelspec": {
    "display_name": "uqlm",


### PR DESCRIPTION
Update the Gemini model name from `gemini-pro` to `gemini-1.5-flash`. The following change is required for two reasons.

- Gemini-pro have been deprecated on GCP
- Gemini flash models have higher rate limit compared to pro models.