### PR TITLE
Dataloader patterns use raw strings

### DIFF
--- a/uqlm/utils/dataloader.py
+++ b/uqlm/utils/dataloader.py
@@ -74,7 +74,7 @@ _dataset_default_params = {
         "extra_processing": {
             "regex_filters": [
                 {
-                    "pattern": "#### ([-+]?\d*\\.\d+|[-+]?\d+)",  # regex pattern
+                    "pattern": r"#### ([-+]?\d*\.\d+|[-+]?\d+)",  # regex pattern
                     "col": "answer",  # dataset col to apply pattern to
                     "operation": "search",  # type of regex operation
                     "group": 1,
@@ -108,7 +108,7 @@ _dataset_default_params = {
             "rename_columns": {"question_concat": "question", "Answer": "answer"},
             "regex_filters": [
                 {
-                    "pattern": "#### ([-+]?\d*\\.\d+|[-+]?\d+)",  # get numbers only (like gsm8k)
+                    "pattern": r"#### ([-+]?\d*\.\d+|[-+]?\d+)",  # get numbers only (like gsm8k)
                     "col": "answer",
                     "operation": "search",
                     "group": 1,


### PR DESCRIPTION
# Change

- dataloader module now uses raw strings in its pattern to avoid syntax warning from python about escape characters

# Tests

This change affects the svamp and gsm8k datasets which both load fine with this change:

<img width="393" alt="image" src="https://github.com/user-attachments/assets/0be61b92-bda5-4289-ab3c-995732c6e21f" />
<img width="398" alt="image" src="https://github.com/user-attachments/assets/b7f48de6-ab40-4f14-8ca5-a132162ed595" />
