### PR TITLE
Simplify `LLMPanel` workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 # uqlm: Uncertainty Quantification for Language Models
 
 [![Build Status](https://github.com/cvs-health/uqlm/actions/workflows/ci.yaml/badge.svg)](https://github.com/cvs-health/uqlm/actions)
-[![Documentation Status](https://img.shields.io/badge/docs-latest-blue.svg)](https://cvs-health.github.io/uqlm/latest/index.html)
 [![PyPI version](https://badge.fury.io/py/uqlm.svg)](https://pypi.org/project/uqlm/)
+[![Documentation Status](https://img.shields.io/badge/docs-latest-blue.svg)](https://cvs-health.github.io/uqlm/latest/index.html)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![](https://img.shields.io/badge/arXiv-2504.19254-B31B1B.svg)](https://arxiv.org/abs/2504.19254)
 

--- a/examples/judges_demo.ipynb
+++ b/examples/judges_demo.ipynb
@@ -66,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {
     "tags": []
    },
@@ -95,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {
     "tags": []
    },
@@ -173,7 +173,7 @@
        "4  There were 78 dollars in Olivia's wallet. She ...     63"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -186,7 +186,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {
     "tags": []
    },
@@ -208,7 +208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {
     "tags": []
    },
@@ -235,7 +235,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {
     "tags": []
    },
@@ -255,98 +255,6 @@
    "source": [
     "<a id='section2'></a>\n",
     "## 2. Generate responses and confidence scores"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### `LLMJudge()` - Customizable class for LLM-as-a-Judge offering three off-the-shelf templates.\n",
-    "\n",
-    "#### 📋 Class Attributes\n",
-    "\n",
-    "<table style=\"border-collapse: collapse; width: 100%; border: 1px solid rgba(127, 127, 127, 0.2);\">\n",
-    "  <tr>\n",
-    "    <th style=\"background-color: rgba(200, 200, 200, 0.2); width: 20%; padding: 8px; text-align: left; border: 1px solid rgba(127, 127, 127, 0.2);\">Parameter</th>\n",
-    "    <th style=\"background-color: rgba(200, 200, 200, 0.2); width: 25%; padding: 8px; text-align: left; border: 1px solid rgba(127, 127, 127, 0.2);\">Type & Default</th>\n",
-    "    <th style=\"background-color: rgba(200, 200, 200, 0.2); width: 55%; padding: 8px; text-align: left; border: 1px solid rgba(127, 127, 127, 0.2);\">Description</th>\n",
-    "  </tr>\n",
-    "  <tr>\n",
-    "    <td style=\"font-weight: bold; padding: 8px; border: 1px solid rgba(127, 127, 127, 0.2);\">llm</td>\n",
-    "    <td style=\"padding: 8px; border: 1px solid rgba(127, 127, 127, 0.2);\">BaseChatModel<br><code>default=None</code></td>\n",
-    "    <td style=\"padding: 8px; border: 1px solid rgba(127, 127, 127, 0.2);\">A langchain llm `BaseChatModel`. User is responsible for specifying temperature and other relevant parameters to the constructor of the provided `llm` object.</td>\n",
-    "  </tr>\n",
-    "  <tr>\n",
-    "    <td style=\"font-weight: bold; padding: 8px; border: 1px solid rgba(127, 127, 127, 0.2);\">scoring_template</td>\n",
-    "    <td style=\"padding: 8px; border: 1px solid rgba(127, 127, 127, 0.2);\">str<br><code>default='true_false_uncertain'</code></td>\n",
-    "    <td style=\"padding: 8px; border: 1px solid rgba(127, 127, 127, 0.2);\">Specifies which off-the-shelf template to use, if any. Three off-the-shelf templates offered: incorrect/uncertain/correct (0/0.5/1), incorrect/correct (0/1), and continuous score (0 to 1). These templates are respectively specified as 'true_false_uncertain', 'true_false', and 'continuous'.</td>\n",
-    "  </tr> \n",
-    "  <tr>\n",
-    "    <td style=\"font-weight: bold; padding: 8px; border: 1px solid rgba(127, 127, 127, 0.2);\">system_prompt</td>\n",
-    "    <td style=\"padding: 8px; border: 1px solid rgba(127, 127, 127, 0.2);\">str or None<br><code>default=\"You are a helpful assistant.\"</code></td>\n",
-    "    <td style=\"padding: 8px; border: 1px solid rgba(127, 127, 127, 0.2);\">Optional argument for user to provide custom system prompt for the LLM.</td>\n",
-    "  </tr>  \n",
-    "  <tr>\n",
-    "    <td style=\"font-weight: bold; padding: 8px; border: 1px solid rgba(127, 127, 127, 0.2);\">max_calls_per_min</td>\n",
-    "    <td style=\"padding: 8px; border: 1px solid rgba(127, 127, 127, 0.2);\">int<br><code>default=None</code></td>\n",
-    "    <td style=\"padding: 8px; border: 1px solid rgba(127, 127, 127, 0.2);\">Specifies how many API calls to make per minute to avoid rate limit errors. By default, no limit is specified.</td>\n",
-    "  </tr>\n",
-    "</table>\n",
-    "\n",
-    "#### 🔍 Parameter Groups\n",
-    "\n",
-    "<div style=\"display: flex; gap: 20px; margin-bottom: 20px\">\n",
-    "  <div style=\"flex: 1; padding: 10px; background-color: rgba(0, 100, 200, 0.1); border-radius: 5px; border: 1px solid rgba(0, 100, 200, 0.2);\">\n",
-    "    <p style=\"font-weight: bold\">🧠 LLM-Specific</p>\n",
-    "    <ul>\n",
-    "      <li><code>llm</code></li>\n",
-    "      <li><code>system_prompt</code></li>\n",
-    "    </ul>\n",
-    "  </div>\n",
-    "  <div style=\"flex: 1; padding: 10px; background-color: rgba(0, 200, 0, 0.1); border-radius: 5px; border: 1px solid rgba(0, 200, 0, 0.2);\">\n",
-    "    <p style=\"font-weight: bold\">📊 Confidence Scores</p>\n",
-    "    <ul>\n",
-    "      <li><code>scoring_template</code></li>\n",
-    "    </ul>\n",
-    "  </div>\n",
-    "  <div style=\"flex: 1; padding: 10px; background-color: rgba(200, 0, 200, 0.1); border-radius: 5px; border: 1px solid rgba(200, 0, 200, 0.2);\">\n",
-    "    <p style=\"font-weight: bold\">⚡ Performance</p>\n",
-    "    <ul>\n",
-    "      <li><code>max_calls_per_min</code></li>\n",
-    "    </ul>\n",
-    "  </div>\n",
-    "</div>\n",
-    "\n",
-    "#### 💻 Usage Examples\n",
-    "\n",
-    "```python\n",
-    "# Basic usage with default parameters\n",
-    "judge = LLMJudge(llm=llm)\n",
-    "\n",
-    "# Using 'continuous' scoring template\n",
-    "judge = LLMJudge(llm=llm, scoring_template='continuous')\n",
-    "\n",
-    "# Configuration with rate limiting\n",
-    "judge = LLMJudge(llm=llm, max_calls_per_min=200) \n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "# Note: We opt to aggregate several judges into a panel of judges using `LLMPanel` below.\n",
-    "self_judge = LLMJudge(\n",
-    "    llm=original_llm, max_calls_per_min=250, scoring_template=\"true_false\"\n",
-    ")\n",
-    "judge1 = LLMJudge(\n",
-    "    llm=gemini_pro, max_calls_per_min=250, scoring_template=\"true_false_uncertain\"\n",
-    ")\n",
-    "# judge2 = LLMJudge(langchain_llm=gemini_flash, max_calls_per_min=250, scoring_template='continuous')"
    ]
   },
   {
@@ -385,8 +293,12 @@
     "    <td style=\"padding: 8px; border: 1px solid rgba(127, 127, 127, 0.2);\">int<br><code>default=None</code></td>\n",
     "    <td style=\"padding: 8px; border: 1px solid rgba(127, 127, 127, 0.2);\">Specifies how many API calls to make per minute to avoid rate limit errors. By default, no limit is specified.</td>\n",
     "  </tr>\n",
+    "  <tr>\n",
+    "    <td style=\"font-weight: bold; padding: 8px; border: 1px solid rgba(127, 127, 127, 0.2);\">scoring_templates</td>\n",
+    "    <td style=\"padding: 8px; border: 1px solid rgba(127, 127, 127, 0.2);\">int<br><code>default=None</code></td>\n",
+    "    <td style=\"padding: 8px; border: 1px solid rgba(127, 127, 127, 0.2);\">Specifies which off-the-shelf template to use for each judge. Three off-the-shelf templates offered: incorrect/uncertain/correct (0/0.5/1), incorrect/correct (0/1), and continuous score (0 to 1). These templates are respectively specified as 'true_false_uncertain', 'true_false', and 'continuous'. If specified, must be of equal length to `judges` list. Defaults to 'true_false_uncertain' template used by Chen and Mueller (2023) for each judge.</td>\n",
+    "  </tr>\n",
     "</table>\n",
-    "\n",
     "\n",
     "#### 🔍 Parameter Groups\n",
     "\n",
@@ -402,6 +314,7 @@
     "    <p style=\"font-weight: bold\">📊 Confidence Scores</p>\n",
     "    <ul>\n",
     "      <li><code>judges</code></li>\n",
+    "      <li><code>scoring_templates</code></li>        \n",
     "    </ul>\n",
     "  </div>\n",
     "  <div style=\"flex: 1; padding: 10px; background-color: rgba(200, 0, 200, 0.1); border-radius: 5px; border: 1px solid rgba(200, 0, 200, 0.2);\">\n",
@@ -423,26 +336,21 @@
     "\n",
     "# Using two judges, one with continuous template\n",
     "panel = LLMPanel(\n",
-    "    llm=llm, judges=[llm, LLMJudge(llm=llm2, scoring_template='continuous')]\n",
+    "    llm=llm, judges=[llm, llm2], scoring_templates=['true_false_uncertain', 'continuous']\n",
     ")\n",
     "```"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
     "panel = LLMPanel(\n",
-    "    llm=original_llm,\n",
-    "    judges=[\n",
-    "        self_judge,  # uses same LLM as a judge\n",
-    "        judge1,  # customized template (continuous)\n",
-    "        gemini_flash,  # constructs directly from BaseChatModel using default template\n",
-    "    ],\n",
+    "    llm=original_llm, judges=[original_llm,  gemini_pro,  gemini_flash],   \n",
     ")"
    ]
   },
@@ -491,7 +399,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {
     "tags": []
    },
@@ -516,7 +424,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {
     "tags": []
    },
@@ -559,11 +467,11 @@
        "      <td>When you solve this math problem only return t...</td>\n",
        "      <td>145</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>0.0</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>0.666667</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.0</td>\n",
        "      <td>1.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -571,21 +479,21 @@
        "      <td>When you solve this math problem only return t...</td>\n",
        "      <td>19 pounds</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>0.0</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>0.666667</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.0</td>\n",
        "      <td>1.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>When you solve this math problem only return t...</td>\n",
-       "      <td>3</td>\n",
+       "      <td>$3</td>\n",
        "      <td>1.0</td>\n",
        "      <td>1.0</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>1.000000</td>\n",
+       "      <td>1.0</td>\n",
        "      <td>1.0</td>\n",
        "      <td>1.0</td>\n",
        "      <td>1.0</td>\n",
@@ -597,7 +505,7 @@
        "      <td>1.0</td>\n",
        "      <td>1.0</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>1.000000</td>\n",
+       "      <td>1.0</td>\n",
        "      <td>1.0</td>\n",
        "      <td>1.0</td>\n",
        "      <td>1.0</td>\n",
@@ -609,7 +517,7 @@
        "      <td>1.0</td>\n",
        "      <td>1.0</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>1.000000</td>\n",
+       "      <td>1.0</td>\n",
        "      <td>1.0</td>\n",
        "      <td>1.0</td>\n",
        "      <td>1.0</td>\n",
@@ -622,19 +530,19 @@
        "                                              prompt   response  judge_1  \\\n",
        "0  When you solve this math problem only return t...        145      1.0   \n",
        "1  When you solve this math problem only return t...  19 pounds      1.0   \n",
-       "2  When you solve this math problem only return t...          3      1.0   \n",
+       "2  When you solve this math problem only return t...         $3      1.0   \n",
        "3  When you solve this math problem only return t...        198      1.0   \n",
        "4  When you solve this math problem only return t...         63      1.0   \n",
        "\n",
-       "   judge_2  judge_3       avg  max  min  median  \n",
-       "0      0.0      1.0  0.666667  1.0  0.0     1.0  \n",
-       "1      0.0      1.0  0.666667  1.0  0.0     1.0  \n",
-       "2      1.0      1.0  1.000000  1.0  1.0     1.0  \n",
-       "3      1.0      1.0  1.000000  1.0  1.0     1.0  \n",
-       "4      1.0      1.0  1.000000  1.0  1.0     1.0  "
+       "   judge_2  judge_3  avg  max  min  median  \n",
+       "0      1.0      1.0  1.0  1.0  1.0     1.0  \n",
+       "1      1.0      1.0  1.0  1.0  1.0     1.0  \n",
+       "2      1.0      1.0  1.0  1.0  1.0     1.0  \n",
+       "3      1.0      1.0  1.0  1.0  1.0     1.0  \n",
+       "4      1.0      1.0  1.0  1.0  1.0     1.0  "
       ]
      },
-     "execution_count": 10,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -661,7 +569,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {
     "tags": []
    },
@@ -706,11 +614,11 @@
        "      <td>When you solve this math problem only return t...</td>\n",
        "      <td>145</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>0.0</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>0.666667</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.0</td>\n",
        "      <td>1.0</td>\n",
        "      <td>145</td>\n",
        "      <td>True</td>\n",
@@ -720,11 +628,11 @@
        "      <td>When you solve this math problem only return t...</td>\n",
        "      <td>19 pounds</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>0.0</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>0.666667</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.0</td>\n",
        "      <td>1.0</td>\n",
        "      <td>19</td>\n",
        "      <td>True</td>\n",
@@ -732,11 +640,11 @@
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>When you solve this math problem only return t...</td>\n",
-       "      <td>3</td>\n",
+       "      <td>$3</td>\n",
        "      <td>1.0</td>\n",
        "      <td>1.0</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>1.000000</td>\n",
+       "      <td>1.0</td>\n",
        "      <td>1.0</td>\n",
        "      <td>1.0</td>\n",
        "      <td>1.0</td>\n",
@@ -750,7 +658,7 @@
        "      <td>1.0</td>\n",
        "      <td>1.0</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>1.000000</td>\n",
+       "      <td>1.0</td>\n",
        "      <td>1.0</td>\n",
        "      <td>1.0</td>\n",
        "      <td>1.0</td>\n",
@@ -764,7 +672,7 @@
        "      <td>1.0</td>\n",
        "      <td>1.0</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>1.000000</td>\n",
+       "      <td>1.0</td>\n",
        "      <td>1.0</td>\n",
        "      <td>1.0</td>\n",
        "      <td>1.0</td>\n",
@@ -779,19 +687,19 @@
        "                                              prompt   response  judge_1  \\\n",
        "0  When you solve this math problem only return t...        145      1.0   \n",
        "1  When you solve this math problem only return t...  19 pounds      1.0   \n",
-       "2  When you solve this math problem only return t...          3      1.0   \n",
+       "2  When you solve this math problem only return t...         $3      1.0   \n",
        "3  When you solve this math problem only return t...        198      1.0   \n",
        "4  When you solve this math problem only return t...         63      1.0   \n",
        "\n",
-       "   judge_2  judge_3       avg  max  min  median answer  response_correct  \n",
-       "0      0.0      1.0  0.666667  1.0  0.0     1.0    145              True  \n",
-       "1      0.0      1.0  0.666667  1.0  0.0     1.0     19              True  \n",
-       "2      1.0      1.0  1.000000  1.0  1.0     1.0      3              True  \n",
-       "3      1.0      1.0  1.000000  1.0  1.0     1.0    198              True  \n",
-       "4      1.0      1.0  1.000000  1.0  1.0     1.0     63              True  "
+       "   judge_2  judge_3  avg  max  min  median answer  response_correct  \n",
+       "0      1.0      1.0  1.0  1.0  1.0     1.0    145              True  \n",
+       "1      1.0      1.0  1.0  1.0  1.0     1.0     19              True  \n",
+       "2      1.0      1.0  1.0  1.0  1.0     1.0      3              True  \n",
+       "3      1.0      1.0  1.0  1.0  1.0     1.0    198              True  \n",
+       "4      1.0      1.0  1.0  1.0  1.0     1.0     63              True  "
       ]
      },
-     "execution_count": 11,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -807,7 +715,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {
     "tags": []
    },
@@ -816,17 +724,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Judge 1 precision: 0.9\n",
-      "Judge 1 recall: 0.8307692307692308\n",
-      "Judge 1 f1-score: 0.864\n",
+      "Judge 1 precision: 0.8620689655172413\n",
+      "Judge 1 recall: 0.78125\n",
+      "Judge 1 f1-score: 0.819672131147541\n",
       " \n",
-      "Judge 2 precision: 0.92\n",
-      "Judge 2 recall: 0.35384615384615387\n",
-      "Judge 2 f1-score: 0.5111111111111111\n",
+      "Judge 2 precision: 0.9375\n",
+      "Judge 2 recall: 0.9375\n",
+      "Judge 2 f1-score: 0.9375\n",
       " \n",
-      "Judge 3 precision: 0.921875\n",
-      "Judge 3 recall: 0.9076923076923077\n",
-      "Judge 3 f1-score: 0.9147286821705426\n",
+      "Judge 3 precision: 0.9090909090909091\n",
+      "Judge 3 recall: 0.9375\n",
+      "Judge 3 f1-score: 0.9230769230769231\n",
       " \n"
      ]
     }
@@ -876,15 +784,15 @@
  ],
  "metadata": {
   "environment": {
-   "kernel": "uqlm",
-   "name": "workbench-notebooks.m125",
+   "kernel": "uqlm_my_test",
+   "name": "workbench-notebooks.m126",
    "type": "gcloud",
-   "uri": "us-docker.pkg.dev/deeplearning-platform-release/gcr.io/workbench-notebooks:m125"
+   "uri": "us-docker.pkg.dev/deeplearning-platform-release/gcr.io/workbench-notebooks:m126"
   },
   "kernelspec": {
-   "display_name": "uqlm",
+   "display_name": "uqlm_my_test",
    "language": "python",
-   "name": "uqlm"
+   "name": "uqlm_my_test"
   },
   "language_info": {
    "codemirror_mode": {
@@ -896,7 +804,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.21"
+   "version": "3.11.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR simplifies the `LLMPanel` workflow by enabling specification of scoring templates in the `LLMPanel` constructor. As part of this PR, the corresponding demo notebook is also updated to remove `LLMJudge` to make it simpler.