### PR TITLE
adding Likert scale scoring  for LLMJudge class

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Note that although we use `ChatVertexAI` in this example, we can use any [LangCh
 *   Categorical LLM-as-a-Judge ([Manakul et al., 2023](https://arxiv.org/abs/2303.08896); [Chen & Mueller, 2023](https://arxiv.org/abs/2308.16175); [Luo et al., 2023](https://arxiv.org/abs/2303.15621))
 *   Continuous LLM-as-a-Judge ([Xiong et al., 2024](https://arxiv.org/abs/2306.13063))
 *   Panel of LLM Judges ([Verga et al., 2024](https://arxiv.org/abs/2404.18796))
+*   Likert Scale Scoring ([Bai et al., 2023](https://arxiv.org/pdf/2306.04181))
 
 ### Ensemble Scorers
 

--- a/examples/judges_demo.ipynb
+++ b/examples/judges_demo.ipynb
@@ -296,7 +296,7 @@
     "  <tr>\n",
     "    <td style=\"font-weight: bold; padding: 8px; border: 1px solid rgba(127, 127, 127, 0.2);\">scoring_templates</td>\n",
     "    <td style=\"padding: 8px; border: 1px solid rgba(127, 127, 127, 0.2);\">int<br><code>default=None</code></td>\n",
-    "    <td style=\"padding: 8px; border: 1px solid rgba(127, 127, 127, 0.2);\">Specifies which off-the-shelf template to use for each judge. Three off-the-shelf templates offered: incorrect/uncertain/correct (0/0.5/1), incorrect/correct (0/1), and continuous score (0 to 1). These templates are respectively specified as 'true_false_uncertain', 'true_false', and 'continuous'. If specified, must be of equal length to `judges` list. Defaults to 'true_false_uncertain' template used by Chen and Mueller (2023) for each judge.</td>\n",
+    "    <td style=\"padding: 8px; border: 1px solid rgba(127, 127, 127, 0.2);\">Specifies which off-the-shelf template to use for each judge. Four off-the-shelf templates offered: incorrect/uncertain/correct (0/0.5/1), incorrect/correct (0/1),continuous score (0 to 1), and likert scale score(1-5 scale,normalized to 0/0.25/0.5/0.75/1).These templates are respectively specified as 'true_false_uncertain', 'true_false','continuous', and 'likert'. If specified, must be of equal length to `judges` list. Defaults to 'true_false_uncertain' template used by Chen and Mueller (2023) for each judge.</td>\n",
     "  </tr>\n",
     "</table>\n",
     "\n",

--- a/examples/judges_demo.ipynb
+++ b/examples/judges_demo.ipynb
@@ -296,7 +296,7 @@
     "  <tr>\n",
     "    <td style=\"font-weight: bold; padding: 8px; border: 1px solid rgba(127, 127, 127, 0.2);\">scoring_templates</td>\n",
     "    <td style=\"padding: 8px; border: 1px solid rgba(127, 127, 127, 0.2);\">int<br><code>default=None</code></td>\n",
-    "    <td style=\"padding: 8px; border: 1px solid rgba(127, 127, 127, 0.2);\">Specifies which off-the-shelf template to use for each judge. Four off-the-shelf templates offered: incorrect/uncertain/correct (0/0.5/1), incorrect/correct (0/1),continuous score (0 to 1), and likert scale score(1-5 scale,normalized to 0/0.25/0.5/0.75/1).These templates are respectively specified as 'true_false_uncertain', 'true_false','continuous', and 'likert'. If specified, must be of equal length to `judges` list. Defaults to 'true_false_uncertain' template used by Chen and Mueller (2023) for each judge.</td>\n",
+    "    <td style=\"padding: 8px; border: 1px solid rgba(127, 127, 127, 0.2);\">Specifies which off-the-shelf template to use for each judge. Four off-the-shelf templates offered: incorrect/uncertain/correct (0/0.5/1), incorrect/correct (0/1), continuous score (0 to 1), and likert scale score (1-5 scale, normalized to 0/0.25/0.5/0.75/1). These templates are respectively specified as 'true_false_uncertain', 'true_false','continuous', and 'likert'. If specified, must be of equal length to `judges` list. Defaults to 'true_false_uncertain' template used by Chen and Mueller (2023) for each judge.</td>\n",
     "  </tr>\n",
     "</table>\n",
     "\n",

--- a/examples/judges_demo.ipynb
+++ b/examples/judges_demo.ipynb
@@ -296,7 +296,7 @@
     "  <tr>\n",
     "    <td style=\"font-weight: bold; padding: 8px; border: 1px solid rgba(127, 127, 127, 0.2);\">scoring_templates</td>\n",
     "    <td style=\"padding: 8px; border: 1px solid rgba(127, 127, 127, 0.2);\">int<br><code>default=None</code></td>\n",
-    "    <td style=\"padding: 8px; border: 1px solid rgba(127, 127, 127, 0.2);\">Specifies which off-the-shelf template to use for each judge. Four off-the-shelf templates offered: incorrect/uncertain/correct (0/0.5/1), incorrect/correct (0/1), continuous score (0 to 1), and likert scale score (1-5 scale, normalized to 0/0.25/0.5/0.75/1). These templates are respectively specified as 'true_false_uncertain', 'true_false','continuous', and 'likert'. If specified, must be of equal length to `judges` list. Defaults to 'true_false_uncertain' template used by Chen and Mueller (2023) for each judge.</td>\n",
+    "    <td style=\"padding: 8px; border: 1px solid rgba(127, 127, 127, 0.2);\">Specifies which off-the-shelf template to use for each judge. Four off-the-shelf templates offered: incorrect/uncertain/correct (0/0.5/1), incorrect/correct (0/1), continuous score (0 to 1), and likert scale score (1-5 scale, normalized to 0/0.25/0.5/0.75/1). These templates are respectively specified as 'true_false_uncertain', 'true_false', 'continuous', and 'likert'. If specified, must be of equal length to `judges` list. Defaults to 'true_false_uncertain' template used by Chen and Mueller (2023) for each judge.</td>\n",
     "  </tr>\n",
     "</table>\n",
     "\n",

--- a/uqlm/judges/judge.py
+++ b/uqlm/judges/judge.py
@@ -65,7 +65,6 @@ Your task is to score the answer on a scale from 1 to 5, with 5 being the highes
 3 - Partially correct: The answer has some correct elements but also contains errors.
 4 - Mostly correct: The answer is largely accurate with only minor errors or omissions.
 5 - Completely correct: The answer is fully accurate and comprehensive.
-You should score the answer based on your knowledge of the corresponding question.
 Give only the numerical score (1-5) with no explanation.
 """
 

--- a/uqlm/judges/judge.py
+++ b/uqlm/judges/judge.py
@@ -107,10 +107,10 @@ class LLMJudge(ResponseGenerator):
             Specifies how many api calls to make per minute to avoid a rate limit error. By default, no
             limit is specified.
 
-        scoring_template : {'true_false_uncertain', 'true_false', 'continuous','likert'}, default='true_false_uncertain'
+        scoring_template : {'true_false_uncertain', 'true_false', 'continuous', 'likert'}, default='true_false_uncertain'
              specifies which off-the-shelf template to use, if any. Four off-the-shelf templates offered:
              incorrect/uncertain/correct (0/0.5/1), incorrect/correct (0/1), continuous score (0 to 1), and likert scale score ( 1-5 scale, normalized to 0/0.25/0.5/0.75/1).
-             These templates are respectively specified as 'true_false_uncertain', 'true_false','continuous', and 'likert'
+             These templates are respectively specified as 'true_false_uncertain', 'true_false', 'continuous', and 'likert'
 
         system_prompt : str or None, default=None
             Optional argument for user to provide custom system prompt. If None, a default instruction

--- a/uqlm/judges/judge.py
+++ b/uqlm/judges/judge.py
@@ -93,8 +93,8 @@ class LLMJudge(ResponseGenerator):
     ) -> None:
         """
         Class for using LLM-as-a-judge to score proposed answers to questions based on correctness. Four off-the-shelf
-        templates are offered: incorrect/uncertain/correct (0/0.5/1), incorrect/correct (0/1),continuous score (0 to 1), and likert
-        scale score(1-5 scale,normalized to 0/0.25/0.5/0.75/1).
+        templates are offered: incorrect/uncertain/correct (0/0.5/1), incorrect/correct (0/1), continuous score (0 to 1), and likert
+        scale score ( 1-5 scale, normalized to 0/0.25/0.5/0.75/1).
         Customization is also supported for user-provided classification-based judging templates. The correct/incorrect/uncertain
         template is based on Chen and Mueller(2023) :footcite:`chen2023quantifyinguncertaintyanswerslanguage`
 
@@ -110,7 +110,7 @@ class LLMJudge(ResponseGenerator):
 
         scoring_template : {'true_false_uncertain', 'true_false', 'continuous','likert'}, default='true_false_uncertain'
              specifies which off-the-shelf template to use, if any. Four off-the-shelf templates offered:
-             incorrect/uncertain/correct (0/0.5/1), incorrect/correct (0/1),continuous score (0 to 1), and likert scale score(1-5 scale,normalized to 0/0.25/0.5/0.75/1).
+             incorrect/uncertain/correct (0/0.5/1), incorrect/correct (0/1), continuous score (0 to 1), and likert scale score ( 1-5 scale, normalized to 0/0.25/0.5/0.75/1).
              These templates are respectively specified as 'true_false_uncertain', 'true_false','continuous', and 'likert'
 
         system_prompt : str or None, default=None

--- a/uqlm/scorers/panel.py
+++ b/uqlm/scorers/panel.py
@@ -51,7 +51,7 @@ class LLMPanel(UncertaintyQuantifier):
             
         scoring_templates : List[str], default=None
              Specifies which off-the-shelf template to use for each judge. Four off-the-shelf templates offered:
-             incorrect/uncertain/correct (0/0.5/1), incorrect/correct (0/1), continuous score (0 to 1), and likert scale score(1-5 scale,normalized to 0/0.25/0.5/0.75/1).
+             incorrect/uncertain/correct (0/0.5/1), incorrect/correct (0/1), continuous score (0 to 1), and likert scale score ( 1-5 scale, normalized to 0/0.25/0.5/0.75/1).
              These templates are respectively specified as 'true_false_uncertain', 'true_false','continuous', and 'likert'
              If specified, must be of equal length to `judges` list. Defaults to 'true_false_uncertain' template
              used by Chen and Mueller (2023) :footcite:`chen2023quantifyinguncertaintyanswerslanguage` for each judge.

--- a/uqlm/scorers/panel.py
+++ b/uqlm/scorers/panel.py
@@ -52,7 +52,7 @@ class LLMPanel(UncertaintyQuantifier):
         scoring_templates : List[str], default=None
              Specifies which off-the-shelf template to use for each judge. Four off-the-shelf templates offered:
              incorrect/uncertain/correct (0/0.5/1), incorrect/correct (0/1), continuous score (0 to 1), and likert scale score ( 1-5 scale, normalized to 0/0.25/0.5/0.75/1).
-             These templates are respectively specified as 'true_false_uncertain', 'true_false','continuous', and 'likert'
+             These templates are respectively specified as 'true_false_uncertain', 'true_false', 'continuous', and 'likert'
              If specified, must be of equal length to `judges` list. Defaults to 'true_false_uncertain' template
              used by Chen and Mueller (2023) :footcite:`chen2023quantifyinguncertaintyanswerslanguage` for each judge.
         """

--- a/uqlm/scorers/panel.py
+++ b/uqlm/scorers/panel.py
@@ -50,9 +50,9 @@ class LLMPanel(UncertaintyQuantifier):
             Optional argument for user to provide custom system prompt
             
         scoring_templates : List[str], default=None
-             Specifies which off-the-shelf template to use for each judge. Three off-the-shelf templates offered:
-             incorrect/uncertain/correct (0/0.5/1), incorrect/correct (0/1), and continuous score (0 to 1).
-             These templates are respectively specified as 'true_false_uncertain', 'true_false', and 'continuous'. 
+             Specifies which off-the-shelf template to use for each judge. Four off-the-shelf templates offered:
+             incorrect/uncertain/correct (0/0.5/1), incorrect/correct (0/1), continuous score (0 to 1), and likert scale score(1-5 scale,normalized to 0/0.25/0.5/0.75/1).
+             These templates are respectively specified as 'true_false_uncertain', 'true_false','continuous', and 'likert'
              If specified, must be of equal length to `judges` list. Defaults to 'true_false_uncertain' template
              used by Chen and Mueller (2023) :footcite:`chen2023quantifyinguncertaintyanswerslanguage` for each judge.
         """


### PR DESCRIPTION
Implementing a 5-label(1-5) likert scale template. These values map to scores of  [0, .25, 0.5, 0.75, 1] respectively .
issue #5 
Adding @dylanbouchard  for review .