### PR TITLE
Unit tests Tuner class

### DIFF
--- a/tests/test_blackboxuq.py
+++ b/tests/test_blackboxuq.py
@@ -17,6 +17,7 @@ import json
 from uqlm.scorers import BlackBoxUQ
 from uqlm.scorers.baseclass.uncertainty import DEFAULT_BLACK_BOX_SCORERS
 from langchain_openai import AzureChatOpenAI
+import sys
 
 datafile_path = "tests/data/scorers/blackbox_results_file.json"
 with open(datafile_path, "r") as f:
@@ -69,11 +70,16 @@ async def test_bbuq(monkeypatch, mock_llm):
     uqe_default = BlackBoxUQ(llm=mock_llm, scorers=None)
     assert len(uqe_default.scorers) == len(DEFAULT_BLACK_BOX_SCORERS)
 
-    # Test initiating BertScorer and BLEURT Scorer
-    try:
-        # BLEURT scorer is optional dependecies, this line will raise import error for first time user and GA workflow
-        BlackBoxUQ(llm=mock_llm, scorers=["bert_score", "bleurt"])
-        # Developers will have BLEURT installed, so we raised ImportError to get coverage on 'except' block
-        raise (ImportError)
-    except ImportError:
-        pass
+    # Mock the entire bleurt module structure for testing
+    class  MockBLEURTScorer:
+        def __init__(self):
+            pass
+
+    # Create a proper module structure that matches the import path
+    class MockBlackBoxModule:
+        BLEURTScorer = MockBLEURTScorer
+    
+    # Directly modify sys.modules dictionary with the complete module structure
+    monkeypatch.setitem(sys.modules, "uqlm.black_box", MockBlackBoxModule())
+
+    BlackBoxUQ(llm=mock_llm, scorers=["bert_score", "bleurt"])

--- a/tests/test_blackboxuq.py
+++ b/tests/test_blackboxuq.py
@@ -71,14 +71,14 @@ async def test_bbuq(monkeypatch, mock_llm):
     assert len(uqe_default.scorers) == len(DEFAULT_BLACK_BOX_SCORERS)
 
     # Mock the entire bleurt module structure for testing
-    class  MockBLEURTScorer:
+    class MockBLEURTScorer:
         def __init__(self):
             pass
 
     # Create a proper module structure that matches the import path
     class MockBlackBoxModule:
         BLEURTScorer = MockBLEURTScorer
-    
+
     # Directly modify sys.modules dictionary with the complete module structure
     monkeypatch.setitem(sys.modules, "uqlm.black_box", MockBlackBoxModule())
 

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -14,17 +14,18 @@
 
 import json
 import os
-import numpy as np
+import importlib.util
+import sys
 import shutil
+import numpy as np
 import subprocess
 import importlib.resources as resources
+import unittest
 from uqlm.black_box import BertScorer, BLEURTScorer, CosineScorer, MatchScorer
 from uqlm.black_box.baseclass.similarity_scorer import SimilarityScorer
-import unittest
-import pytest
-import sys
-import io
 from contextlib import redirect_stdout
+import pytest
+import io
 
 datafile_path = "tests/data/similarity/similarity_results_file.json"
 with open(datafile_path, "r") as f:
@@ -41,10 +42,13 @@ def test_bert():
 
 
 def test_bluert_import_error():
-    subprocess.run(["pip", "uninstall", "-y", "bleurt"], capture_output=True)
-    with pytest.raises(ImportError) as import_error:
-        BLEURTScorer()
-    assert "The bleurt package is required to use BLEURTScorer but is not installed. Please install it using:" in str(import_error.value)
+    result = subprocess.run(["pip", "uninstall", "-y", "bleurt"], capture_output=True)
+    result.check_returncode()  # Wait for subprocess to finish and check for errors
+    bleurt_installed = importlib.util.find_spec("bleurt") is not None
+    if not bleurt_installed:
+        with pytest.raises(ImportError) as import_error:
+            BLEURTScorer()
+        assert "The bleurt package is required to use BLEURTScorer but is not installed. Please install it using:" in str(import_error.value)
 
 
 @unittest.skipIf((os.getenv("CI") == "true"), "Skipping test in CI due to dependency on GitHub repository.")

--- a/tests/test_tuner.py
+++ b/tests/test_tuner.py
@@ -53,22 +53,25 @@ class TestTuner:
         assert len(normalized_weights) == len(weights)
 
     def test_validation_errors_and_optimization_paths(self):
-        # test input validation
-        tuner = Tuner()
-        tuner.k = 1
-        with pytest.raises(ValueError):
-            tuner._validate_tuning_inputs()
+        # test input validation (k=1)
+        with pytest.raises(ValueError) as e:
+            Tuner().tune_params(score_lists=[self.score_lists[0]], correct_indicators=self.correct_indicators)
+        assert "Tuning only applies if more than scorer component is present." in str(e.value)
+
         # test unsupported weights_objective
-        tuner.k = 3
-        tuner.weights_objective = "invalid"
-        with pytest.raises(ValueError):
-            tuner._validate_tuning_inputs()
+        with pytest.raises(ValueError) as e:
+            Tuner().tune_params(score_lists=self.score_lists, correct_indicators=self.correct_indicators, weights_objective="invalid")
+        assert "Only 'fbeta_score', 'accuracy_score', 'balanced_accuracy_score', 'roc_auc_score', and 'log_loss' are supported for tuning objectives." in str(e.value)
 
         # test unsupported thresh_objective
-        tuner.weights_objective = "roc_auc"
-        tuner.thresh_objective = "invalid"
-        with pytest.raises(ValueError):
-            tuner._validate_tuning_inputs()
+        with pytest.raises(ValueError) as e:
+            Tuner().tune_params(score_lists=self.score_lists, correct_indicators=self.correct_indicators, thresh_objective="invalid")
+        assert "Only 'fbeta_score', 'accuracy_score', 'balanced_accuracy_score' are supported for tuning objectives." in str(e.value)
+
+        # test thresh_objective must match weights_objective for any threshold-dependent weights_objective
+        with pytest.raises(ValueError) as e:
+            Tuner().tune_params(self.score_lists, self.correct_indicators, weights_objective="fbeta_score", thresh_objective="accuracy_score")
+        assert "thresh_objective must match weights_objective for any threshold-dependent weights_objective." in str(e.value)
 
         # test threshold optimization with different paths
         # cover  tune_threshold() method  and different objective function evaluations
@@ -77,6 +80,8 @@ class TestTuner:
 
         # k=2: different objectives (optimize_jointly=False path)
         Tuner().tune_params(self.score_lists[:2], self.correct_indicators, weights_objective="roc_auc", thresh_objective="fbeta_score")
+        # k=2: same objectives (optimize_jointly=True, grid search)
+        Tuner().tune_params(self.score_lists[:2], self.correct_indicators, weights_objective="fbeta_score", thresh_objective="fbeta_score")
         # k=3: same objectives (optimize_jointly=True, grid search)
         Tuner().tune_params(self.score_lists, self.correct_indicators, weights_objective="fbeta_score", thresh_objective="fbeta_score")
         # k=3: different objectives (optimize_jointly=False, separate optimization)
@@ -86,4 +91,3 @@ class TestTuner:
         Tuner().tune_params(extended_lists, self.correct_indicators)
         # log_loss objective (obj_multiplier = -1 path)
         Tuner().tune_params(self.score_lists, self.correct_indicators, weights_objective="log_loss", thresh_objective="fbeta_score")
-

--- a/uqlm/utils/tuner.py
+++ b/uqlm/utils/tuner.py
@@ -166,13 +166,13 @@ class Tuner:
     def _validate_tuning_inputs(self):
         """Helper function to validate tuning inputs."""
         if self.k == 1:
-            raise ValueError("""Tuning only applies if more than scorer component is present.""")
+            raise ValueError("Tuning only applies if more than scorer component is present.")
 
         if self.weights_objective not in self.objective_to_func:
             raise ValueError(
                 """
-            Only 'fbeta_score', 'accuracy_score', 'balanced_accuracy_score', 'roc_auc_score', and 'log_loss' are supported for tuning objectives.
-            """
+                Only 'fbeta_score', 'accuracy_score', 'balanced_accuracy_score', 'roc_auc_score', and 'log_loss' are supported for tuning objectives.
+                """
             )
         if self.thresh_objective not in ["fbeta_score", "accuracy_score", "balanced_accuracy_score"]:
             raise ValueError(


### PR DESCRIPTION
This PR includes following changes
- Additional unit tests for tuner class to achieve 100% code coverage
- Modify existing unit tests to check error after initiating the class object, instead of simply updating the attributes and calling the method
- Update unit tests for BlackBox Scorers to handle edge case (scorer=["bluert"]), without install bluert package
- Additional checks to ensure bluert package isn't installed before running unit tests for bluert scorer