### PR TITLE
Input attributes to define path of downloaded sentence-transformer model 

### DIFF
--- a/uqlm/black_box/cosine.py
+++ b/uqlm/black_box/cosine.py
@@ -22,7 +22,7 @@ from uqlm.black_box.baseclass.similarity_scorer import SimilarityScorer
 
 
 class CosineScorer(SimilarityScorer):
-    def __init__(self, transformer: str = "all-MiniLM-L6-v2") -> None:
+    def __init__(self, transformer: str = "all-MiniLM-L6-v2", transformer_path: str = None) -> None:
         """Compute cosine similarity betwee original and candidate responses.
 
         Parameters
@@ -30,12 +30,17 @@ class CosineScorer(SimilarityScorer):
         transformer : str (HuggingFace sentence transformer), default='all-MiniLM-L6-v2'
             Specifies which huggingface sentence transformer to use when computing cosine distance. See
             https://huggingface.co/sentence-transformers?sort_models=likes#models
-            for more information. The recommended sentence transformer is 'all-MiniLM-L6-v2'.
+            for more information. The recommended sentence transformer is 'all-MiniLM-L6-v2'. This parameter is ignored if transformer_path is provided.
+
+        transformer_path : str, default=None
+            Specifies the path to the sentence transformer model. If None, the transformer model will be accessed from HuggingFace using transformer library.
         """
         from sentence_transformers import SentenceTransformer
 
         self.transformer = transformer
-        self.model = SentenceTransformer(f"sentence-transformers/{transformer}")
+        self.transformer_path = transformer_path
+        model_str = transformer_path if transformer_path else f"sentence-transformers/{transformer}"
+        self.model = SentenceTransformer(model_str)
 
     def evaluate(self, responses: List[str], sampled_responses: List[List[str]]) -> List[float]:
         """

--- a/uqlm/black_box/nli.py
+++ b/uqlm/black_box/nli.py
@@ -24,7 +24,7 @@ from uqlm.black_box.baseclass.similarity_scorer import SimilarityScorer
 
 
 class NLIScorer(SimilarityScorer):
-    def __init__(self, device: Any = None, verbose: bool = False, nli_model_name: str = "microsoft/deberta-large-mnli", max_length: int = 2000) -> None:
+    def __init__(self, device: Any = None, verbose: bool = False, nli_model_name: str = "microsoft/deberta-large-mnli", nli_model_path: str = None, max_length: int = 2000) -> None:
         """
         A class to computing NLI-based confidence scores. This class offers two types of confidence scores, namely
         noncontradiction probability :footcite:`chen2023quantifyinguncertaintyanswerslanguage` and semantic entropy
@@ -41,7 +41,10 @@ class NLIScorer(SimilarityScorer):
 
         nli_model_name : str, default="microsoft/deberta-large-mnli"
             Specifies which NLI model to use. Must be acceptable input to AutoTokenizer.from_pretrained() and
-            AutoModelForSequenceClassification.from_pretrained()
+            AutoModelForSequenceClassification.from_pretrained(). This parameter is ignored if nli_model_path is provided.
+
+        nli_model_path : str, default=None
+            Specifies the path to the NLI model. If None, the nli_model_name will be accessed from HuggingFace using transformers library.
 
         max_length : int, default=2000
             Specifies the maximum allowed string length. Responses longer than this value will be truncated to
@@ -50,8 +53,9 @@ class NLIScorer(SimilarityScorer):
         self.device = device
         self.verbose = verbose
         self.max_length = max_length
-        self.tokenizer = AutoTokenizer.from_pretrained(nli_model_name)
-        model = AutoModelForSequenceClassification.from_pretrained(nli_model_name)
+        model_str = nli_model_path if nli_model_path else nli_model_name
+        self.tokenizer = AutoTokenizer.from_pretrained(model_str)
+        model = AutoModelForSequenceClassification.from_pretrained(model_str)
         self.model = model.to(self.device) if self.device else model
         self.label_mapping = ["contradiction", "neutral", "entailment"]
 

--- a/uqlm/scorers/baseclass/uncertainty.py
+++ b/uqlm/scorers/baseclass/uncertainty.py
@@ -128,9 +128,9 @@ class UncertaintyQuantifier:
         else:
             return LLMJudge(llm=llm)
 
-    def _setup_nli(self, nli_model_name: Any) -> None:
+    def _setup_nli(self, nli_model_name: str, nli_model_path: str) -> None:
         """Set up NLI scorer"""
-        self.nli_scorer = NLIScorer(nli_model_name=self.nli_model_name, device=self.device, max_length=self.max_length, verbose=self.verbose)
+        self.nli_scorer = NLIScorer(nli_model_name=nli_model_name, nli_model_path=nli_model_path, device=self.device, max_length=self.max_length, verbose=self.verbose)
 
     def _update_best(self, best_responses: List[str]) -> None:
         """Updates best"""

--- a/uqlm/scorers/entropy.py
+++ b/uqlm/scorers/entropy.py
@@ -21,7 +21,20 @@ from uqlm.scorers.baseclass.uncertainty import UncertaintyQuantifier, UQResult
 
 class SemanticEntropy(UncertaintyQuantifier):
     def __init__(
-        self, llm=None, postprocessor: Any = None, device: Any = None, use_best: bool = True, best_response_selection: str = "discrete", system_prompt: str = "You are a helpful assistant.", max_calls_per_min: Optional[int] = None, use_n_param: bool = False, sampling_temperature: float = 1.0, verbose: bool = False, nli_model_name: str = "microsoft/deberta-large-mnli", max_length: int = 2000
+        self,
+        llm=None,
+        postprocessor: Any = None,
+        device: Any = None,
+        use_best: bool = True,
+        best_response_selection: str = "discrete",
+        system_prompt: str = "You are a helpful assistant.",
+        max_calls_per_min: Optional[int] = None,
+        use_n_param: bool = False,
+        sampling_temperature: float = 1.0,
+        verbose: bool = False,
+        nli_model_name: str = "microsoft/deberta-large-mnli",
+        nli_model_path: str = None,
+        max_length: int = 2000,
     ) -> None:
         """
         Class for computing discrete and token-probability-based semantic entropy and associated confidence scores. For more on semantic entropy, refer to Farquhar et al.(2024) :footcite:`farquhar2024detectinghallucinations`.
@@ -68,18 +81,22 @@ class SemanticEntropy(UncertaintyQuantifier):
             Specifies which NLI model to use. Must be acceptable input to AutoTokenizer.from_pretrained() and
             AutoModelForSequenceClassification.from_pretrained()
 
+        nli_model_path : str, default=None
+            Specifies the path to the NLI model. If None, the nli_model_name will be accessed from HuggingFace using transformers library.
+
         max_length : int, default=2000
             Specifies the maximum allowed string length. Responses longer than this value will be truncated to
             avoid OutOfMemoryError
         """
         super().__init__(llm=llm, device=device, system_prompt=system_prompt, max_calls_per_min=max_calls_per_min, use_n_param=use_n_param, postprocessor=postprocessor)
         self.nli_model_name = nli_model_name
+        self.nli_model_path = nli_model_path
         self.max_length = max_length
         self.verbose = verbose
         self.use_best = use_best
         self.sampling_temperature = sampling_temperature
         self.prompts = None
-        self._setup_nli(nli_model_name)
+        self._setup_nli(nli_model_name, nli_model_path)
         self.best_response_selection = best_response_selection
 
     async def generate_and_score(self, prompts: List[str], num_responses: int = 5) -> UQResult:


### PR DESCRIPTION
This PR update classes related to Cosine similarity and NLI Scorers. The following modules are modified:

- nli.py: Added new attribute "nli_model_path"
- cosine.py: Added new attribute "transformer_path"
- blackbox.py: Add three new input attributes to lackBoxUQ class ("nli_model_path, cosine_transformer, cosine_transformer_path)
- entropy.py: Updated SemanticEntropy class to use "nli_model_path" attribute
- uncertainty.py: Updated "_setup_nli" method