### PR TITLE
Db/missing logprobs unittest skip

### DIFF
--- a/tests/test_load_example_dataset.py
+++ b/tests/test_load_example_dataset.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import platform
 import pytest
+import unittest
 import pandas as pd
 from uqlm.utils.dataloader import load_example_dataset, list_dataset_names, _combine_question_and_choices
 from uqlm.utils.dataloader import _dataset_processing
@@ -29,6 +32,7 @@ def test_load_nonexistent_dataset():
         load_example_dataset("nonexistent_dataset")
 
 
+@unittest.skipIf(((os.getenv("CI") == "true") & (platform.system() == "Darwin")), "Skipping test in macOS CI due to connection issues.")
 @pytest.mark.flaky(reruns=3)
 def test_load_dataset_with_processing():
     df = load_example_dataset("gsm8k", n=100, cols=["question", "answer"])
@@ -56,6 +60,7 @@ def test_combine_question_and_choices_list_case():
     assert len(result) == 1
 
 
+@unittest.skipIf(((os.getenv("CI") == "true") & (platform.system() == "Darwin")), "Skipping test in macOS CI due to connection issues.")
 @pytest.mark.flaky(reruns=3)
 def test_load_example_dataset_with_concat_all():
     # test the if split == “all”: branch and concatenate_datasets call

--- a/uqlm/utils/response_generator.py
+++ b/uqlm/utils/response_generator.py
@@ -181,10 +181,15 @@ class ResponseGenerator:
                 self.progress_bar.update(self.progress_task, advance=1)
         if hasattr(self.llm, "logprobs"):
             if self.llm.logprobs:
-                if "logprobs_result" in result.generations[0][0].generation_info:
-                    logprobs = [np.nan if "logprobs_result" not in result.generations[0][i].generation_info else result.generations[0][i].generation_info["logprobs_result"] for i in range(count)]
-                elif "logprobs" in result.generations[0][0].generation_info:
-                    logprobs = [np.nan if "logprobs" not in result.generations[0][i].generation_info else result.generations[0][i].generation_info["logprobs"]["content"] for i in range(count)]
+                for i in range(count):
+                    if "logprobs_result" in result.generations[0][i].generation_info:
+                        logprobs[i] = result.generations[0][i].generation_info["logprobs_result"]
+
+                    elif "logprobs" in result.generations[0][i].generation_info:
+                        if "content" in "logprobs" in result.generations[0][i].generation_info["logprobs"]:
+                            logprobs[i] = result.generations[0][i].generation_info["logprobs"]["content"]
+                    else:
+                        logprobs[i] = np.nan
         return {"logprobs": logprobs, "responses": [result.generations[0][i].text for i in range(count)]}
 
     @staticmethod

--- a/uqlm/utils/response_generator.py
+++ b/uqlm/utils/response_generator.py
@@ -184,7 +184,7 @@ class ResponseGenerator:
                 if "logprobs_result" in result.generations[0][0].generation_info:
                     logprobs = [np.nan if "logprobs_result" not in result.generations[0][i].generation_info else result.generations[0][i].generation_info["logprobs_result"] for i in range(count)]
                 elif "logprobs" in result.generations[0][0].generation_info:
-                    logprobs = [np.nan if "logprobs" not in result.generations[0][0].generation_info else result.generations[0][i].generation_info["logprobs"]["content"] for i in range(count)]
+                    logprobs = [np.nan if "logprobs" not in result.generations[0][i].generation_info else result.generations[0][i].generation_info["logprobs"]["content"] for i in range(count)]
         return {"logprobs": logprobs, "responses": [result.generations[0][i].text for i in range(count)]}
 
     @staticmethod


### PR DESCRIPTION
This PR makes the following updates:
* skip flaky tests that tend to fail in MacOS on CI due to Hugging Face connection issues. These can be run locally and on other OS for CI
* Fix indexing issue for missing logprobs handling