### PR TITLE
use bert_score class rather than function for 43x speedup

### DIFF
--- a/uqlm/black_box/bert.py
+++ b/uqlm/black_box/bert.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-
 import numpy as np
 from typing import Any, List, Optional
 from bert_score import BERTScorer
@@ -29,7 +28,7 @@ class BertScorer(SimilarityScorer):
         """
         Class for computing BERTScore values between original responses and candidates. For more on
         BERTScore, refer to Zhang et al.(2020) :footcite:`zhang2020bertscoreevaluatingtextgeneration`.
-        
+
         Parameters
         ----------
         device : torch.device input or torch.device object, default=None
@@ -37,8 +36,9 @@ class BertScorer(SimilarityScorer):
             leverage the GPU.
         """
         from transformers import logging
+
         logging.set_verbosity_error()
-        self.bert_scorer = BERTScorer(device=device, lang='en')
+        self.bert_scorer = BERTScorer(device=device, lang="en")
 
     def evaluate(self, responses: List[str], sampled_responses: List[List[str]], progress_bar: Optional[Progress] = None) -> List[float]:
         """

--- a/uqlm/scorers/black_box.py
+++ b/uqlm/scorers/black_box.py
@@ -212,7 +212,7 @@ class BlackBoxUQ(UncertaintyQuantifier):
             if scorer == "exact_match":
                 self.scorer_objects["exact_match"] = MatchScorer()
             elif scorer == "bert_score":
-                self.scorer_objects["bert_score"] = BertScorer()
+                self.scorer_objects["bert_score"] = BertScorer(device=self.device)
             elif scorer == "cosine_sim":
                 self.scorer_objects["cosine_sim"] = CosineScorer(transformer=self.sentence_transformer)
             elif scorer in ["semantic_negentropy", "noncontradiction"]:


### PR DESCRIPTION
This refactor replaces use of `bert_score.score` with `bert_score.BERTScorer.score` for a ~43x speedup. While the former (old approach) re-checks and re-assigns `torch.device` with each use of `score`, the latter (updated approach) assigns `torch.device` only once during instantiation. 
<img width="1096" height="453" alt="image" src="https://github.com/user-attachments/assets/dde6f78f-6cae-4add-8942-e3dee3e29c62" />
