### PR TITLE
Semantic density notebook

### DIFF
--- a/examples/semantic_density_demo.ipynb
+++ b/examples/semantic_density_demo.ipynb
@@ -63,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "tags": []
    },
@@ -208,7 +208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {
     "tags": []
    },
@@ -743,7 +743,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {
     "tags": []
    },


### PR DESCRIPTION
## Description
This PR adds a new notebook that demonstrates how to use the `SemanticDensity` scorer introduced in #209.

## Notes
- I noticed that the evaluation scores in section 3.2 are actually kinda low, especially compared to scores from the other demo notebooks 😅 I'd be happy to rerun the notebook with a different model for better results. 