### PR TITLE
Longform Feature: evaluate method to compute semantic entropy

### DIFF
--- a/examples/claim_qa_demo.ipynb
+++ b/examples/claim_qa_demo.ipynb
@@ -172,9 +172,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Prompts:  ['write a paragraph about Paul McCartney', 'write a paragraph about John Lennon']\n",
-      "Responses:  ['Paul McCartney is a renowned British musician, singer, and songwriter, best known as a co-founder of the legendary band The Beatles, which revolutionized pop music in the 1960s. Born on June 18, 1942, in Liverpool, England, McCartney showcased his musical talent from a young age, playing various instruments and writing songs. His partnership with John Lennon formed one of the most successful songwriting duos in history, producing timeless classics like \"Hey Jude,\" \"Let It Be,\" and \"Yesterday.\" After The Beatles disbanded in 1970, McCartney embarked on a successful solo career, releasing numerous albums and hits, and forming the band Wings. In addition to his music, he is an advocate for animal rights and various social causes. With numerous awards, including multiple Grammys, McCartney\\'s influence on music and culture remains profound, solidifying his status as one of the most significant figures in the history of modern music.', 'John Lennon was a groundbreaking British musician, singer, and songwriter, best known as a co-founder of the legendary band The Beatles. Born on October 9, 1940, in Liverpool, England, he rose to fame in the 1960s, contributing to the band\\'s innovative sound and cultural impact with iconic songs like \"Imagine\" and \"Hey Jude.\" Lennon was not only celebrated for his musical genius but also for his outspoken advocacy for peace and social change during a tumultuous era. After The Beatles disbanded, he pursued a successful solo career, further exploring themes of love, peace, and personal introspection. Tragically, his life was cut short on December 8, 1980, when he was assassinated outside his home in New York City, leaving behind a lasting legacy that continues to inspire artists and activists worldwide.']\n",
-      "Computation time: 58.43605136871338 seconds\n"
+      "Computation time: 140.32325506210327 seconds\n"
      ]
     }
    ],
@@ -193,14 +191,66 @@
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>prompt</th>\n",
+       "      <th>response</th>\n",
+       "      <th>response_scores_exact_match</th>\n",
+       "      <th>factoid_scores_exact_match</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>write a paragraph about Paul McCartney</td>\n",
+       "      <td>Paul McCartney is a legendary British musician...</td>\n",
+       "      <td>0.215517</td>\n",
+       "      <td>[0.0, 0.5, 0.25, 0.0, 0.0, 0.75, 0.0, 0.0, 0.7...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>write a paragraph about John Lennon</td>\n",
+       "      <td>John Lennon was a quintessential figure in 20t...</td>\n",
+       "      <td>0.152778</td>\n",
+       "      <td>[0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.0, 0.0, ...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
       "text/plain": [
-       "{'prompts': ['write a paragraph about Paul McCartney',\n",
-       "  'write a paragraph about John Lennon'],\n",
-       " 'responses': ['Paul McCartney is a renowned British musician, singer, and songwriter, best known as a co-founder of the legendary band The Beatles, which revolutionized pop music in the 1960s. Born on June 18, 1942, in Liverpool, England, McCartney showcased his musical talent from a young age, playing various instruments and writing songs. His partnership with John Lennon formed one of the most successful songwriting duos in history, producing timeless classics like \"Hey Jude,\" \"Let It Be,\" and \"Yesterday.\" After The Beatles disbanded in 1970, McCartney embarked on a successful solo career, releasing numerous albums and hits, and forming the band Wings. In addition to his music, he is an advocate for animal rights and various social causes. With numerous awards, including multiple Grammys, McCartney\\'s influence on music and culture remains profound, solidifying his status as one of the most significant figures in the history of modern music.',\n",
-       "  'John Lennon was a groundbreaking British musician, singer, and songwriter, best known as a co-founder of the legendary band The Beatles. Born on October 9, 1940, in Liverpool, England, he rose to fame in the 1960s, contributing to the band\\'s innovative sound and cultural impact with iconic songs like \"Imagine\" and \"Hey Jude.\" Lennon was not only celebrated for his musical genius but also for his outspoken advocacy for peace and social change during a tumultuous era. After The Beatles disbanded, he pursued a successful solo career, further exploring themes of love, peace, and personal introspection. Tragically, his life was cut short on December 8, 1980, when he was assassinated outside his home in New York City, leaving behind a lasting legacy that continues to inspire artists and activists worldwide.'],\n",
-       " 'response_scores': {'exact_match': [0.25, 0.39285714285714285]},\n",
-       " 'factoid_scores': {'exact_match': [[0.5, 0.25, 0.0, 0.0, 0.5, 0.0, 0.5],\n",
-       "   [0.0, 0.0, 0.0, 0.5, 0.5, 1.0, 0.75]]}}"
+       "                                   prompt  \\\n",
+       "0  write a paragraph about Paul McCartney   \n",
+       "1     write a paragraph about John Lennon   \n",
+       "\n",
+       "                                            response  \\\n",
+       "0  Paul McCartney is a legendary British musician...   \n",
+       "1  John Lennon was a quintessential figure in 20t...   \n",
+       "\n",
+       "   response_scores_exact_match  \\\n",
+       "0                     0.215517   \n",
+       "1                     0.152778   \n",
+       "\n",
+       "                          factoid_scores_exact_match  \n",
+       "0  [0.0, 0.5, 0.25, 0.0, 0.0, 0.75, 0.0, 0.0, 0.7...  \n",
+       "1  [0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.0, 0.0, ...  "
       ]
      },
      "execution_count": 7,
@@ -209,28 +259,7 @@
     }
    ],
    "source": [
-    "result.to_dict()[\"data\"]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "8926ee64",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "dict_keys(['factoids', 'response_fact_questions', 'response_fact_questions_responses', 'response_fact_questions_sampled_responses'])"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "result.to_dict()[\"metadata\"].keys()"
+    "result.to_df()"
    ]
   },
   {
@@ -243,7 +272,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "id": "4f65d93c",
    "metadata": {},
    "outputs": [],
@@ -254,30 +283,81 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 9,
    "id": "c00bd1cd",
    "metadata": {},
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>prompt</th>\n",
+       "      <th>response</th>\n",
+       "      <th>response_scores_exact_match</th>\n",
+       "      <th>factoid_scores_exact_match</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>write a paragraph about Paul McCartney</td>\n",
+       "      <td>Paul McCartney is a legendary British musician...</td>\n",
+       "      <td>0.163462</td>\n",
+       "      <td>[0.0, 0.0, 0.0, 0.0, 0.5, 0.0, 0.75, 1.0, 0.25...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>write a paragraph about John Lennon</td>\n",
+       "      <td>John Lennon was a quintessential figure in 20t...</td>\n",
+       "      <td>0.200000</td>\n",
+       "      <td>[0.0, 0.25, 0.5, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0,...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
       "text/plain": [
-       "{'prompts': ['write a paragraph about Paul McCartney',\n",
-       "  'write a paragraph about John Lennon'],\n",
-       " 'responses': ['Paul McCartney is a renowned British musician, singer, and songwriter, best known as a co-founder of the legendary band The Beatles, which revolutionized pop music in the 1960s. Born on June 18, 1942, in Liverpool, England, McCartney showcased his musical talent from a young age, playing various instruments and writing songs. His partnership with John Lennon formed one of the most successful songwriting duos in history, producing timeless classics like \"Hey Jude,\" \"Let It Be,\" and \"Yesterday.\" After The Beatles disbanded in 1970, McCartney embarked on a successful solo career, releasing numerous albums and hits, and forming the band Wings. In addition to his music, he is an advocate for animal rights and various social causes. With numerous awards, including multiple Grammys, McCartney\\'s influence on music and culture remains profound, solidifying his status as one of the most significant figures in the history of modern music.',\n",
-       "  'John Lennon was a groundbreaking British musician, singer, and songwriter, best known as a co-founder of the legendary band The Beatles. Born on October 9, 1940, in Liverpool, England, he rose to fame in the 1960s, contributing to the band\\'s innovative sound and cultural impact with iconic songs like \"Imagine\" and \"Hey Jude.\" Lennon was not only celebrated for his musical genius but also for his outspoken advocacy for peace and social change during a tumultuous era. After The Beatles disbanded, he pursued a successful solo career, further exploring themes of love, peace, and personal introspection. Tragically, his life was cut short on December 8, 1980, when he was assassinated outside his home in New York City, leaving behind a lasting legacy that continues to inspire artists and activists worldwide.'],\n",
-       " 'response_scores': {'exact_match': [0.42857142857142855,\n",
-       "   0.42857142857142855]},\n",
-       " 'factoid_scores': {'exact_match': [[1.0, 0.0, 0.0, 0.5, 0.0, 0.5, 1.0],\n",
-       "   [0.25, 0.25, 0.0, 0.5, 0.75, 0.75, 0.5]]}}"
+       "                                   prompt  \\\n",
+       "0  write a paragraph about Paul McCartney   \n",
+       "1     write a paragraph about John Lennon   \n",
+       "\n",
+       "                                            response  \\\n",
+       "0  Paul McCartney is a legendary British musician...   \n",
+       "1  John Lennon was a quintessential figure in 20t...   \n",
+       "\n",
+       "   response_scores_exact_match  \\\n",
+       "0                     0.163462   \n",
+       "1                     0.200000   \n",
+       "\n",
+       "                          factoid_scores_exact_match  \n",
+       "0  [0.0, 0.0, 0.0, 0.0, 0.5, 0.0, 0.75, 1.0, 0.25...  \n",
+       "1  [0.0, 0.25, 0.5, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0,...  "
       ]
      },
-     "execution_count": 12,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "result2.to_dict()[\"data\"]"
+    "result2.to_df()"
    ]
   },
   {
@@ -290,7 +370,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "id": "9e7af64c",
    "metadata": {},
    "outputs": [],
@@ -301,29 +381,81 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 11,
    "id": "99b968eb",
    "metadata": {},
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>prompt</th>\n",
+       "      <th>response</th>\n",
+       "      <th>response_scores_exact_match</th>\n",
+       "      <th>factoid_scores_exact_match</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>write a paragraph about Paul McCartney</td>\n",
+       "      <td>Paul McCartney is a legendary British musician...</td>\n",
+       "      <td>0.284483</td>\n",
+       "      <td>[0.0, 0.5, 0.0, 0.5, 0.0, 0.5, 0.5, 1.0, 1.0, ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>write a paragraph about John Lennon</td>\n",
+       "      <td>John Lennon was a quintessential figure in 20t...</td>\n",
+       "      <td>0.180556</td>\n",
+       "      <td>[0.0, 0.25, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0,...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
       "text/plain": [
-       "{'prompts': ['write a paragraph about Paul McCartney',\n",
-       "  'write a paragraph about John Lennon'],\n",
-       " 'responses': ['Paul McCartney is a renowned British musician, singer, and songwriter, best known as a co-founder of the legendary band The Beatles, which revolutionized pop music in the 1960s. Born on June 18, 1942, in Liverpool, England, McCartney showcased his musical talent from a young age, playing various instruments and writing songs. His partnership with John Lennon formed one of the most successful songwriting duos in history, producing timeless classics like \"Hey Jude,\" \"Let It Be,\" and \"Yesterday.\" After The Beatles disbanded in 1970, McCartney embarked on a successful solo career, releasing numerous albums and hits, and forming the band Wings. In addition to his music, he is an advocate for animal rights and various social causes. With numerous awards, including multiple Grammys, McCartney\\'s influence on music and culture remains profound, solidifying his status as one of the most significant figures in the history of modern music.',\n",
-       "  'John Lennon was a groundbreaking British musician, singer, and songwriter, best known as a co-founder of the legendary band The Beatles. Born on October 9, 1940, in Liverpool, England, he rose to fame in the 1960s, contributing to the band\\'s innovative sound and cultural impact with iconic songs like \"Imagine\" and \"Hey Jude.\" Lennon was not only celebrated for his musical genius but also for his outspoken advocacy for peace and social change during a tumultuous era. After The Beatles disbanded, he pursued a successful solo career, further exploring themes of love, peace, and personal introspection. Tragically, his life was cut short on December 8, 1980, when he was assassinated outside his home in New York City, leaving behind a lasting legacy that continues to inspire artists and activists worldwide.'],\n",
-       " 'response_scores': {'exact_match': [0.42857142857142855, 0.4642857142857143]},\n",
-       " 'factoid_scores': {'exact_match': [[1.0, 0.0, 0.0, 0.5, 0.5, 0.0, 1.0],\n",
-       "   [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.25]]}}"
+       "                                   prompt  \\\n",
+       "0  write a paragraph about Paul McCartney   \n",
+       "1     write a paragraph about John Lennon   \n",
+       "\n",
+       "                                            response  \\\n",
+       "0  Paul McCartney is a legendary British musician...   \n",
+       "1  John Lennon was a quintessential figure in 20t...   \n",
+       "\n",
+       "   response_scores_exact_match  \\\n",
+       "0                     0.284483   \n",
+       "1                     0.180556   \n",
+       "\n",
+       "                          factoid_scores_exact_match  \n",
+       "0  [0.0, 0.5, 0.0, 0.5, 0.0, 0.5, 0.5, 1.0, 1.0, ...  \n",
+       "1  [0.0, 0.25, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0,...  "
       ]
      },
-     "execution_count": 13,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "result3.to_dict()[\"data\"]"
+    "result3.to_df()"
    ]
   },
   {


### PR DESCRIPTION
This PR include updates to Claim-QA class.
- [x] Add `evaluate` method that takes factoids/claim set as an input and computes the final score.
- [x] Fixes bug in `score` method.
- [x] Stores factoid-level and response-level score
- [x] Stores additional generations to metadata ( such as response_factoid_questions, response_factoid_questions_responses, ...)
- [x] Updates demo notebook 