### PR TITLE
Drop python 3.9 support

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1415,12 +1415,12 @@ files = [
 google-auth = ">=2.14.1,<3.0.0"
 googleapis-common-protos = ">=1.56.2,<2.0.0"
 grpcio = [
-    {version = ">=1.33.2,<2.0.0", optional = true, markers = "extra == \"grpc\""},
     {version = ">=1.49.1,<2.0.0", optional = true, markers = "python_version >= \"3.11\" and extra == \"grpc\""},
+    {version = ">=1.33.2,<2.0.0", optional = true, markers = "python_version < \"3.11\" and extra == \"grpc\""},
 ]
 grpcio-status = [
-    {version = ">=1.33.2,<2.0.0", optional = true, markers = "extra == \"grpc\""},
     {version = ">=1.49.1,<2.0.0", optional = true, markers = "python_version >= \"3.11\" and extra == \"grpc\""},
+    {version = ">=1.33.2,<2.0.0", optional = true, markers = "extra == \"grpc\""},
 ]
 proto-plus = [
     {version = ">=1.22.3,<2.0.0"},
@@ -1734,7 +1734,7 @@ description = "Lightweight in-process concurrent programming"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version < \"3.14\" and (platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\")"
+markers = "(platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\") and python_version <= \"3.13\""
 files = [
     {file = "greenlet-3.2.4-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:8c68325b0d0acf8d91dde4e6f930967dd52a5302cd4062932a6b2e7c2969f47c"},
     {file = "greenlet-3.2.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:94385f101946790ae13da500603491f04a76b6e4c059dab271b3ce2e283b2590"},
@@ -2666,6 +2666,22 @@ anthropic = ["anthropic (>=0.35.0,<1.0.0)"]
 mistral = ["langchain-mistralai (>=0.2.0,<2.0.0)"]
 
 [[package]]
+name = "langchain-model-profiles"
+version = "0.0.3"
+description = "Centralized reference of LLM capabilities."
+optional = false
+python-versions = "<4.0.0,>=3.10.0"
+groups = ["main"]
+files = [
+    {file = "langchain_model_profiles-0.0.3-py3-none-any.whl", hash = "sha256:76f588327c917df425b004d19d81db634c4b0008ed6497aa3f81b788950d9fc2"},
+    {file = "langchain_model_profiles-0.0.3.tar.gz", hash = "sha256:36d2363953fa13a6f217096ef413f1ebe287161ad5c6d2f728911bc9cd7724c9"},
+]
+
+[package.dependencies]
+tomli = {version = ">=2.0.0,<3.0.0", markers = "python_version < \"3.11\""}
+typing-extensions = ">=4.7.0,<5.0.0"
+
+[[package]]
 name = "langchain-openai"
 version = "1.0.2"
 description = "An integration package connecting OpenAI and LangChain"
@@ -3394,7 +3410,7 @@ description = "Fundamental package for array computing in Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "dev", "test"]
-markers = "python_version <= \"3.12\""
+markers = "python_version < \"3.13\""
 files = [
     {file = "numpy-1.26.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9ff0f4f29c51e2803569d7a51c2304de5554655a60c5d776e35b4a41413830d0"},
     {file = "numpy-1.26.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2e4ee3380d6de9c9ec04745830fd9e2eccb3e6cf790d39d7b98ffd19b0dd754a"},
@@ -4015,9 +4031,9 @@ files = [
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.22.4", markers = "python_version < \"3.11\""},
     {version = ">=1.23.2", markers = "python_version == \"3.11\""},
     {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
+    {version = ">=1.22.4", markers = "python_version < \"3.11\""},
 ]
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
@@ -7256,4 +7272,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10, <4.0"
-content-hash = "7d4a2a1b28b0691ca557ecbcd5b7b45590dd2333a5cbc1f59bad53e5c21c91f6"
+content-hash = "d1a2f62305d4fe317238b2d073bd66f2a39769f6d6739a17cd0efea9817a79dd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ keywords = ["LLM", "large language model", "LLM evaluation", "hallucination", "u
 [tool.poetry.dependencies]
 python = ">=3.10, <4.0"
 langchain = ">=1.0.0,<1.1.0"
+langchain-model-profiles = "^0.0.3"
 transformers = "^4.45.2"
 scikit-learn = [
     { version = "^1.5.2", markers = "python_version < '3.13'" },


### PR DESCRIPTION
### Background
We are making change to keep up with the Python support versions as Python 3.9 reached End of life on 2025-10-31. Revisited libraries to up version as much as we could through this PR.

### Libraries analysis
- poetry.dependencies
   - langchain: We are using langchain_core imports. The imports that we are using has been around since 0.1.0 and still fully supported at 1.0.0. Langchain-core minimum python >= 3.10 req introduced at 1.0.0. langchain 1.0.0 started using langchain-core 1.0.0.
   - langchain-core: Removed langchain-core as separate dependency where installing langchain will automatically install langchain-core with right version
   - scikit-learn: Newer version of scikit-learn 1.7.x was released for python >= 3.13 and used ^ to include patch + minor version updates
   - numpy: numpy needs to stay <2.0.0 due to transformers will go broken/not guaranteed for numpy 2.x 
   - matplotlib: Starting 3.10.0 minimum python version 3.10 was introduced
   - pandas: There was no breaking change but "^2.3.0" is newer version. This isn't related to python 3.10.
   - bert-score: Already up to date
   - sentence-transformers: All versions below 5.1.2, minimum python req is 3.9
   - datasets: All versions below 4.4.0, minimum python req is 3.9
   - rich: All versions below 14.2.0, minimum python req is 3.8
   - ipywidgets: 8.1.x is newest release as well as minimum python req is 3.7
- dev.dependencies
   - python-dotenv: All versions below 1.2.1, minimum python req is 3.8
   - langchain-openai: Min python version req 3.10 introduced at 1.0.0
   - langchain-google-vertexai: Min python version req 3.10 introduced at 3.0.0. We do get warnings regarding urllib3 but this was already introduced at 2.1.2.