### PR TITLE
Feature/enable all white box scorers

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,7 @@ The notebooks are organized into core methods, long-form techniques, and advance
 | [White-Box UQ (Single-Generation)](https://github.com/cvs-health/uqlm/blob/main/examples/white_box_single_generation_demo.ipynb) | Fastest and most efficient UQ when you have token probabilities | Requires token probability access | Negligible (single generation) |
 | [White-Box UQ (Multi-Generation)](https://github.com/cvs-health/uqlm/blob/main/examples/white_box_multi_generation_demo.ipynb) | Higher accuracy UQ when compute budget allows | Requires token probability access | Medium-High (multiple generations) |
 | [LLM-as-a-Judge](https://github.com/cvs-health/uqlm/blob/main/examples/judges_demo.ipynb) | Leveraging one or more LLMs to assess hallucination likelihood | All LLMs (API-only access) | Low-Medium (depends on which judge(s)) |
+| [Ensemble with White-Box Scorers](https://github.com/cvs-health/uqlm/blob/main/examples/ensemble_white_box_scorers_demo.ipynb) | Combining white-box scorers (single-gen, top-logprobs, sampled-logprobs, p_true) in one ensemble | Requires token probability access | Varies by scorers selected |
 | [Train a UQ Ensemble](https://github.com/cvs-health/uqlm/blob/main/examples/ensemble_tuning_demo.ipynb) | Maximizing performance by combining multiple UQ methods | Depends on ensemble components | Low-High (depends on selected components) |
 
 ### Tutorials for Long-Form Uncertainty Quantification Methods (for long-text outputs)

--- a/examples/ensemble_white_box_scorers_demo.ipynb
+++ b/examples/ensemble_white_box_scorers_demo.ipynb
@@ -1,0 +1,695 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Testing New White-Box Scorers in UQEnsemble\n",
+    "\n",
+    "This notebook demonstrates that UQEnsemble now supports all 9 white-box scorers (previously only 2 were supported)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Import required libraries\n",
+    "from uqlm.scorers.shortform.ensemble import UQEnsemble\n",
+    "from langchain_openai import ChatOpenAI\n",
+    "\n",
+    "# Note: You'll need to set your OpenAI API key\n",
+    "# os.environ[\"OPENAI_API_KEY\"] = \"your-api-key-here\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Test Single-Generation Scorers\n",
+    "\n",
+    "These scorers use a single response with its logprobs:\n",
+    "- `min_probability` - Minimum token probability\n",
+    "- `sequence_probability` - Overall sequence probability (length-normalized)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Single-generation scorers accepted!\n",
+      "White-box components: ['min_probability', 'sequence_probability']\n",
+      "WhiteBoxUQ scorers: ['min_probability', 'sequence_probability']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Create LLM with logprobs enabled\n",
+    "llm = ChatOpenAI(temperature=0.7, model=\"gpt-3.5-turbo\", logprobs=True)\n",
+    "\n",
+    "# Test single-generation scorers\n",
+    "ensemble_single = UQEnsemble(llm=llm, scorers=[\"min_probability\", \"sequence_probability\"], device=\"cpu\")\n",
+    "\n",
+    "print(\"✅ Single-generation scorers accepted!\")\n",
+    "print(f\"White-box components: {ensemble_single.white_box_components}\")\n",
+    "print(f\"WhiteBoxUQ scorers: {ensemble_single.white_box_object.scorers}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "📊 Results:\n",
+      "Response: The capital of France is Paris.\n",
+      "Min Probability: 0.9996\n",
+      "Sequence Probability: 0.9999\n",
+      "Ensemble Score: 0.9998\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Generate and score with single-generation scorers\n",
+    "prompts = [\"What is the capital of France?\"]\n",
+    "\n",
+    "result_single = await ensemble_single.generate_and_score(\n",
+    "    prompts=prompts,\n",
+    "    num_responses=1,  # Only need 1 response for single-generation scorers\n",
+    "    show_progress_bars=True,\n",
+    ")\n",
+    "\n",
+    "print(\"\\n📊 Results:\")\n",
+    "print(f\"Response: {result_single.data['responses'][0]}\")\n",
+    "print(f\"Min Probability: {result_single.data['min_probability'][0]:.4f}\")\n",
+    "print(f\"Sequence Probability: {result_single.data['sequence_probability'][0]:.4f}\")\n",
+    "print(f\"Ensemble Score: {result_single.data['ensemble_scores'][0]:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Test Top-Logprobs Scorers\n",
+    "\n",
+    "These scorers use the top-k alternative tokens at each position:\n",
+    "- `min_token_negentropy` - Minimum negentropy across tokens\n",
+    "- `mean_token_negentropy` - Average negentropy across tokens\n",
+    "- `probability_margin` - Mean difference between top-2 token probabilities"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Top-logprobs scorers accepted!\n",
+      "White-box components: ['min_token_negentropy', 'mean_token_negentropy', 'probability_margin']\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/kaushiktummalapalli/Desktop/uqlm/uqlm/scorers/shortform/white_box.py:200: UQLMBetaWarning: Scorers based on top_logprobs ('mean_token_negentropy','min_token_negentropy','probability_margin') is in beta. Please use with caution as it may change in future releases.\n",
+      "  beta_warning(\"Scorers based on top_logprobs ('mean_token_negentropy','min_token_negentropy','probability_margin') is in beta. Please use with caution as it may change in future releases.\")\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Test top-logprobs scorers (will show beta warning)\n",
+    "ensemble_top = UQEnsemble(llm=llm, scorers=[\"min_token_negentropy\", \"mean_token_negentropy\", \"probability_margin\"], device=\"cpu\")\n",
+    "\n",
+    "print(\"✅ Top-logprobs scorers accepted!\")\n",
+    "print(f\"White-box components: {ensemble_top.white_box_components}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6395725fb67a46559d906978f6724d70",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "📊 Results:\n",
+      "Response: The capital of France is Paris.\n",
+      "Min Token Negentropy: 0.9985\n",
+      "Mean Token Negentropy: 0.9997\n",
+      "Probability Margin: 0.9999\n",
+      "Ensemble Score: 0.9994\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Generate and score with top-logprobs scorers\n",
+    "result_top = await ensemble_top.generate_and_score(prompts=prompts, num_responses=1, show_progress_bars=True)\n",
+    "\n",
+    "print(\"\\n📊 Results:\")\n",
+    "print(f\"Response: {result_top.data['responses'][0]}\")\n",
+    "print(f\"Min Token Negentropy: {result_top.data['min_token_negentropy'][0]:.4f}\")\n",
+    "print(f\"Mean Token Negentropy: {result_top.data['mean_token_negentropy'][0]:.4f}\")\n",
+    "print(f\"Probability Margin: {result_top.data['probability_margin'][0]:.4f}\")\n",
+    "print(f\"Ensemble Score: {result_top.data['ensemble_scores'][0]:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Test Sampled-Logprobs Scorers\n",
+    "\n",
+    "These scorers require multiple sampled responses:\n",
+    "- `semantic_negentropy` - Entropy based on semantic clustering\n",
+    "- `semantic_density` - Density-based confidence\n",
+    "- `monte_carlo_probability` - Average sequence probability\n",
+    "- `consistency_and_confidence` - Cosine similarity × response probability"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Sampled-logprobs scorers accepted!\n",
+      "White-box components: ['semantic_negentropy', 'monte_carlo_probability']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Test sampled-logprobs scorers\n",
+    "ensemble_sampled = UQEnsemble(llm=llm, scorers=[\"semantic_negentropy\", \"monte_carlo_probability\"], device=\"cpu\")\n",
+    "\n",
+    "print(\"✅ Sampled-logprobs scorers accepted!\")\n",
+    "print(f\"White-box components: {ensemble_sampled.white_box_components}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d794c50ea1184a38b47f5c15769c575c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "📊 Results:\n",
+      "Response: The capital of France is Paris.\n",
+      "Semantic Negentropy: 1.0000\n",
+      "Monte Carlo Probability: 0.9999\n",
+      "Ensemble Score: 1.0000\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Generate and score with sampled-logprobs scorers\n",
+    "# Note: This will generate multiple responses automatically\n",
+    "result_sampled = await ensemble_sampled.generate_and_score(\n",
+    "    prompts=prompts,\n",
+    "    num_responses=5,  # Need multiple responses for these scorers\n",
+    "    show_progress_bars=True,\n",
+    ")\n",
+    "\n",
+    "print(\"\\n📊 Results:\")\n",
+    "print(f\"Response: {result_sampled.data['responses'][0]}\")\n",
+    "print(f\"Semantic Negentropy: {result_sampled.data['semantic_negentropy'][0]:.4f}\")\n",
+    "print(f\"Monte Carlo Probability: {result_sampled.data['monte_carlo_probability'][0]:.4f}\")\n",
+    "print(f\"Ensemble Score: {result_sampled.data['ensemble_scores'][0]:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Test P(True) Scorer\n",
+    "\n",
+    "This scorer asks the LLM to estimate the probability that its response is true."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ P(True) scorer accepted!\n",
+      "White-box components: ['p_true']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Test p_true scorer\n",
+    "ensemble_ptrue = UQEnsemble(llm=llm, scorers=[\"p_true\"], device=\"cpu\")\n",
+    "\n",
+    "print(\"✅ P(True) scorer accepted!\")\n",
+    "print(f\"White-box components: {ensemble_ptrue.white_box_components}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5d2e322352a54532894b4ee392903ebd",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "📊 Results:\n",
+      "Response: The capital of France is Paris.\n",
+      "P(True): 1.0000\n",
+      "Ensemble Score: 1.0000\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Generate and score with p_true scorer\n",
+    "result_ptrue = await ensemble_ptrue.generate_and_score(prompts=prompts, num_responses=1, show_progress_bars=True)\n",
+    "\n",
+    "print(\"\\n📊 Results:\")\n",
+    "print(f\"Response: {result_ptrue.data['responses'][0]}\")\n",
+    "print(f\"P(True): {result_ptrue.data['p_true'][0]:.4f}\")\n",
+    "print(f\"Ensemble Score: {result_ptrue.data['ensemble_scores'][0]:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Test Combined Ensemble\n",
+    "\n",
+    "Combine different types of scorers in one ensemble!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Combined ensemble created!\n",
+      "White-box components: ['sequence_probability', 'min_token_negentropy', 'monte_carlo_probability', 'p_true']\n",
+      "Black-box components: ['exact_match']\n",
+      "All components: ['sequence_probability', 'min_token_negentropy', 'monte_carlo_probability', 'p_true', 'exact_match']\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/kaushiktummalapalli/Desktop/uqlm/uqlm/scorers/shortform/white_box.py:200: UQLMBetaWarning: Scorers based on top_logprobs ('mean_token_negentropy','min_token_negentropy','probability_margin') is in beta. Please use with caution as it may change in future releases.\n",
+      "  beta_warning(\"Scorers based on top_logprobs ('mean_token_negentropy','min_token_negentropy','probability_margin') is in beta. Please use with caution as it may change in future releases.\")\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Combine multiple scorer types\n",
+    "ensemble_combined = UQEnsemble(\n",
+    "    llm=llm,\n",
+    "    scorers=[\n",
+    "        \"sequence_probability\",  # single-generation\n",
+    "        \"min_token_negentropy\",  # top-logprobs\n",
+    "        \"monte_carlo_probability\",  # sampled-logprobs\n",
+    "        \"p_true\",  # p_true\n",
+    "        \"exact_match\",  # black-box (for comparison)\n",
+    "    ],\n",
+    "    device=\"cpu\",\n",
+    ")\n",
+    "\n",
+    "print(\"✅ Combined ensemble created!\")\n",
+    "print(f\"White-box components: {ensemble_combined.white_box_components}\")\n",
+    "print(f\"Black-box components: {ensemble_combined.black_box_components}\")\n",
+    "print(f\"All components: {ensemble_combined.component_names}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "86a69f3e3f254d5890b586ff14a3bd99",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "📊 Combined Results:\n",
+      "Response: The capital of France is Paris.\n",
+      "\n",
+      "Scores:\n",
+      "  Sequence Probability: 0.9999\n",
+      "  Min Token Negentropy: 0.9987\n",
+      "  Monte Carlo Probability: 0.9999\n",
+      "  P(True): 0.9999\n",
+      "  Exact Match: 1.0000\n",
+      "\n",
+      "  Ensemble Score: 0.9997\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Generate and score with combined ensemble\n",
+    "result_combined = await ensemble_combined.generate_and_score(prompts=prompts, num_responses=5, show_progress_bars=True)\n",
+    "\n",
+    "print(\"\\n📊 Combined Results:\")\n",
+    "print(f\"Response: {result_combined.data['responses'][0]}\")\n",
+    "print(\"\\nScores:\")\n",
+    "print(f\"  Sequence Probability: {result_combined.data['sequence_probability'][0]:.4f}\")\n",
+    "print(f\"  Min Token Negentropy: {result_combined.data['min_token_negentropy'][0]:.4f}\")\n",
+    "print(f\"  Monte Carlo Probability: {result_combined.data['monte_carlo_probability'][0]:.4f}\")\n",
+    "print(f\"  P(True): {result_combined.data['p_true'][0]:.4f}\")\n",
+    "print(f\"  Exact Match: {result_combined.data['exact_match'][0]:.4f}\")\n",
+    "print(f\"\\n  Ensemble Score: {result_combined.data['ensemble_scores'][0]:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Print Ensemble Weights\n",
+    "\n",
+    "See how each scorer contributes to the final ensemble score:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"> \n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       " \n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">         <span style=\"font-weight: bold\">Optimized Ensemble Weights         </span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "         \u001b[1mOptimized Ensemble Weights         \u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">==================================================\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "==================================================\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Scorer                            Weight\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "Scorer                            Weight\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">--------------------------------------------------\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "--------------------------------------------------\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">sequence_probability              <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.2000</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "sequence_probability              \u001b[1;36m0.2000\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">min_token_negentropy              <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.2000</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "min_token_negentropy              \u001b[1;36m0.2000\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">monte_carlo_probability           <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.2000</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "monte_carlo_probability           \u001b[1;36m0.2000\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">p_true                            <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.2000</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "p_true                            \u001b[1;36m0.2000\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">exact_match                       <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.2000</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "exact_match                       \u001b[1;36m0.2000\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">==================================================\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "==================================================\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "ensemble_combined.print_ensemble_weights()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "✅ **All 9 white-box scorers now work with UQEnsemble!**\n",
+    "\n",
+    "Previously supported (2):\n",
+    "- `min_probability`\n",
+    "- ~~`normalized_probability`~~ (deprecated)\n",
+    "\n",
+    "Newly enabled (7):\n",
+    "- `sequence_probability`\n",
+    "- `min_token_negentropy`\n",
+    "- `mean_token_negentropy`\n",
+    "- `probability_margin`\n",
+    "- `semantic_negentropy`\n",
+    "- `semantic_density`\n",
+    "- `monte_carlo_probability`\n",
+    "- `consistency_and_confidence`\n",
+    "- `p_true`"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "uqlm-dKMbh-6T-py3.11",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/uqlm/scorers/shortform/baseclass/uncertainty.py
+++ b/uqlm/scorers/shortform/baseclass/uncertainty.py
@@ -21,6 +21,24 @@ DEFAULT_BLACK_BOX_SCORERS = ["semantic_negentropy", "noncontradiction", "exact_m
 BLACK_BOX_SCORERS = DEFAULT_BLACK_BOX_SCORERS + ["bert_score", "entailment", "semantic_sets_confidence"]
 DEFAULT_WHITE_BOX_SCORERS = ["sequence_probability", "min_probability"]
 
+# All white-box scorers - defined directly to avoid circular imports
+ALL_WHITE_BOX_SCORERS = [
+    # Single-generation scorers (normalized_probability is deprecated)
+    "min_probability",
+    "sequence_probability",
+    # Top-logprobs scorers
+    "min_token_negentropy",
+    "mean_token_negentropy",
+    "probability_margin",
+    # Sampled-logprobs scorers
+    "semantic_negentropy",
+    "semantic_density",
+    "monte_carlo_probability",
+    "consistency_and_confidence",
+    # P(True) scorer
+    "p_true",
+]
+
 
 class ShortFormUQ(UncertaintyQuantifier):
     def __init__(self, llm: Any = None, device: Any = None, system_prompt: Optional[str] = None, max_calls_per_min: Optional[int] = None, use_n_param: bool = False, postprocessor: Optional[Any] = None) -> None:
@@ -55,7 +73,7 @@ class ShortFormUQ(UncertaintyQuantifier):
         """
         super().__init__(llm=llm, device=device, system_prompt=system_prompt, max_calls_per_min=max_calls_per_min, use_n_param=use_n_param, postprocessor=postprocessor)
         self.black_box_names = BLACK_BOX_SCORERS
-        self.white_box_names = DEFAULT_WHITE_BOX_SCORERS
+        self.white_box_names = ALL_WHITE_BOX_SCORERS
         self.default_black_box_names = DEFAULT_BLACK_BOX_SCORERS
 
     def _construct_judge(self, llm: Any = None) -> LLMJudge:


### PR DESCRIPTION
Enable all white-box scorers in UQEnsemble

  PR Description:
  ## Summary
  Enables all 9 white-box scorers in `UQEnsemble`. Previously, only 2 scorers were supported
  (`min_probability` and `normalized_probability`). This PR adds support for all active
  white-box scorers across four categories.

  ## Supported White-Box Scorers

  **Single-generation scorers (2):**
  - `min_probability` - Minimum token probability
  - `sequence_probability` - Length-normalized sequence probability

  **Top-logprobs scorers (3):**
  - `min_token_negentropy` - Minimum negentropy across tokens
  - `mean_token_negentropy` - Average negentropy across tokens
  - `probability_margin` - Mean difference between top-2 token probabilities

  **Sampled-logprobs scorers (4):**
  - `semantic_negentropy` - Entropy based on semantic clustering
  - `semantic_density` - Density-based confidence measure
  - `monte_carlo_probability` - Average sequence probability across samples
  - `consistency_and_confidence` - Cosine similarity × response probability

  **P(True) scorer (1):**
  - `p_true` - LLM's estimate of P(response is true)

  ## Changes Made

  1. **Updated `uqlm/scorers/shortform/baseclass/uncertainty.py`**
     - Added `ALL_WHITE_BOX_SCORERS` constant with all 9 scorer names
     - Changed `self.white_box_names` to use complete list

  2. **Updated `uqlm/scorers/shortform/ensemble.py`**
     - Pass all required parameters to `WhiteBoxUQ` constructor
     - Auto-detect and request `top_k_logprobs=15` when needed
     - Generate sampled responses only when required by specific scorers
     - Pass all required parameters to `white_box_object.score()`

  3. **Added test coverage in `tests/test_ensemble.py`**
     - New test validates all scorer types
     - Tests combined ensemble with multiple scorer types

  4. **Created demo notebook `examples/ensemble_white_box_scorers_demo.ipynb`**
     - Demonstrates all scorer types with real API calls
     - Shows combined ensemble usage

  5. **Updated `examples/README.md`**
     - Added entry for new notebook

  ## Test Results
  ✅ All 28 ensemble tests pass (27 existing + 1 new)
  ✅ No regressions in existing functionality
  ✅ Demo notebook runs successfully with real API calls

  ## Usage Example

  ```python
  from uqlm.scorers.shortform.ensemble import UQEnsemble
  from langchain_openai import ChatOpenAI

  llm = ChatOpenAI(temperature=0.7, logprobs=True)

  ensemble = UQEnsemble(
      llm=llm,
      scorers=[
          "sequence_probability",      # single-generation
          "min_token_negentropy",      # top-logprobs
          "monte_carlo_probability",   # sampled-logprobs
          "p_true"                     # p_true
      ],
      device="cuda"
  )

  result = await ensemble.generate_and_score(
      prompts=["What is the capital of France?"],
      num_responses=5
  )

  Notes

  - All changes maintain backward compatibility with existing code
  - Top-logprobs scorers show a beta warning as they may change in future releases
  - Scorers requiring sampled responses automatically trigger generation