### PR TITLE
Enable automated PyPI publishing via GitHub Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,125 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build package
+        run: uv build
+
+      - name: Upload dist
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish-pypi:
+    needs: build
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout with full history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag is on main
+        run: |
+          git fetch origin main
+          git merge-base --is-ancestor ${{ github.sha }} origin/main || {
+            echo "::error::Tag ${{ github.ref_name }} is not on main. Only tags on main are published to PyPI."
+            exit 1
+          }
+
+      - name: Verify tag matches package version
+        run: |
+          TAG="${{ github.ref_name }}"
+          PKG_VERSION=$(grep '^version' pyproject.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+          if [[ "$TAG" != "v$PKG_VERSION" ]]; then
+            echo "::error::Tag $TAG does not match package version v$PKG_VERSION in pyproject.toml"
+            exit 1
+          fi
+
+      - name: Download dist
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          print-hash: true
+
+  github-release:
+    needs: publish-pypi
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download dist
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Create GitHub Release
+        run: gh release create "${{ github.ref_name }}" dist/* --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-testpypi:
+    needs: build
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Validate branch
+        run: |
+          BRANCH="${{ github.ref_name }}"
+          if [[ "$BRANCH" != "main" && "$BRANCH" != "develop" ]]; then
+            echo "::error::Manual publish to TestPyPI is only allowed from main or develop. Current branch: $BRANCH"
+            exit 1
+          fi
+
+      - name: Download dist
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          print-hash: true


### PR DESCRIPTION
## Summary
Adds a new `publish.yml` GitHub Actions workflow to automate package publishing using PyPI's Trusted Publishers (OIDC). No long-lived API tokens are required — PyPI issues short-lived credentials to GitHub at publish time. Closes #338 

## Workflow Triggers

### Tag Push (`v*.*.*`) | Runs automatically — when you push a git tag matching v*.*.* (e.g. v0.5.9)
1. **build** — Checks out the repo, builds sdist + wheel using `uv build`, uploads artifacts
2. **publish-pypi** — Verifies the tag is on `main`, confirms the tag matches the version in pyproject.toml then publishes to PyPI via OIDC
3. **github-release** — Creates a GitHub Release with auto-generated notes and attaches dist files

### Manual Dispatch (`workflow_dispatch`) | Runs manually — via the "Run workflow" button in GitHub Actions UI
1. **build** — Same as above
2. **publish-testpypi** — Validates the selected branch is `main` or `develop`, then publishes to TestPyPI

## Branch Guards

- **Tag push**: Only tags whose commit is reachable from `main` are published to PyPI. Tags on other branches are rejected.
- **Manual dispatch**: Only `main` and `develop` branches are allowed for TestPyPI publishing.

## Setup Required After Merge

1. Create GitHub Environments `pypi` and `testpypi` in **Settings → Environments**
2. On **pypi.org** → project `uqlm` → Publishing → Add Trusted Publisher:
   - Owner: `cvs-health`, Repo: `uqlm`, Workflow: `publish.yml`, Environment: `pypi`
3. On **test.pypi.org** → same steps with Environment: `testpypi`

## Test Plan

- [ ] Trigger manual dispatch on a non-allowed branch — should fail at "Validate branch" step
- [ ] Push a test tag on a non-main branch — should fail at "Verify tag is on main" step
- [ ] Trigger manual dispatch on `develop` (after TestPyPI trusted publisher is configured) — should build and publish to TestPyPI
- [ ] Push a version tag on `main` (after PyPI trusted publisher is configured) — should publish to PyPI and create a GitHub Release