### PR TITLE
fix: add torch>=2.6.0 minimum version constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
 dependencies = [
     "langchain>=0.3.7",
     "langchain-model-profiles>=0.0.3",
+    "torch>=2.6.0",
     "transformers>=4.45.2,<5.0.0",
     "scikit-learn>=1.5.2,<2.0.0; python_version < '3.13'",
     "scikit-learn>=1.7.0,<2.0.0; python_version >= '3.13'",

--- a/uv.lock
+++ b/uv.lock
@@ -5821,6 +5821,7 @@ dependencies = [
     { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
     { name = "sentence-transformers" },
+    { name = "torch" },
     { name = "transformers" },
 ]
 
@@ -5871,6 +5872,7 @@ requires-dist = [
     { name = "scikit-learn", marker = "python_full_version >= '3.13'", specifier = ">=1.7.0,<2.0.0" },
     { name = "scipy", marker = "python_full_version >= '3.13'", specifier = ">=1.15.0,<2.0.0" },
     { name = "sentence-transformers", specifier = ">=3.4,<6.0" },
+    { name = "torch", specifier = ">=2.6.0" },
     { name = "transformers", specifier = ">=4.45.2,<5.0.0" },
 ]
 


### PR DESCRIPTION
Fixes #400

## What

Adds `torch>=2.6.0` to the `dependencies` list in `pyproject.toml`.

## Why

`uqlm`'s default NLI model (`microsoft/deberta-large-mnli`) ships only `pytorch_model.bin` with no safetensors variant. `AutoModelForSequenceClassification.from_pretrained()` therefore must use `torch.load` internally. Transformers ~4.51 introduced `check_torch_load_is_safe()` (CVE-2025-32434) which raises `ValueError` if torch < 2.6 is detected.

`uqlm` pinned `transformers>=4.45.2` but had no torch lower bound, meaning any user on torch 2.2–2.5 with recent transformers would get a cryptic `ValueError` on instantiation of any NLI-backed scorer (`BlackBoxUQ`, `WhiteBoxUQ`, `SemanticEntropy`, etc.) — before making a single API call.

## Change

```diff
 dependencies = [
     "langchain>=0.3.7",
     "langchain-model-profiles>=0.0.3",
+    "torch>=2.6.0",
     "transformers>=4.45.2,<5.0.0",
```