### PR TITLE
Add Discord badge and community link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,8 @@ It takes a lot of time and effort to use software much less build upon it, so we
 
 ## How to Contribute
 
+For quick questions or community discussion, join our [Discord](https://discord.gg/RjcrAPw43H). For bug reports and feature requests, please use GitHub issues as described below.
+
 ### Reporting Bugs
 
 If you find a bug, please report it by opening an issue on GitHub. Include as much detail as possible:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@
   <a href="https://github.com/astral-sh/ruff">
     <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json" alt="Ruff">
   </a>
+  <a href="https://discord.gg/RjcrAPw43H">
+    <img src="https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white" alt="Discord">
+  </a>
 </p>
 <p align="center">
   <a href="https://www.jmlr.org/papers/v27/25-1557.html">


### PR DESCRIPTION
## Summary
- Adds a Discord badge to the README header linking to the community invite (https://discord.gg/RjcrAPw43H), styled to match the existing shields.io badges.
- Adds a one-line pointer in `CONTRIBUTING.md` directing casual questions to Discord while keeping bug reports and feature requests on GitHub issues.

## Test plan
- [ ] Badge renders correctly in the README header on GitHub.
- [ ] Clicking the badge resolves to a valid Discord invite.
- [ ] CONTRIBUTING.md reads naturally between "How to Contribute" and "Reporting Bugs".

🤖 Generated with [Claude Code](https://claude.com/claude-code)