### PR TITLE
fix(white_box): return NaN instead of None when first-token logprob is missing

### DIFF
--- a/tests/test_p_true.py
+++ b/tests/test_p_true.py
@@ -90,6 +90,20 @@ def test_extract_ptrue_from_logprobs_result():
     assert score != score  # NaN check
 
 
+def test_extract_ptrue_from_logprobs_result_missing_logprob():
+    """Missing first-token logprob must yield NaN, not None.
+
+    A first token without a "logprob" key is undeterminable; the method should
+    return NaN (the same sentinel used for unknown tokens) rather than falling
+    through to an implicit None, which violates its -> float contract and breaks
+    downstream numeric handling (e.g. np.isnan / DataFrame ops).
+    """
+    logprobs_result = [{"token": "true"}]
+    score = PTrueScorer._extract_ptrue_from_logprobs_result(logprobs_result)
+    assert score is not None
+    assert score != score  # NaN check
+
+
 def test_construct_ptrue_prompt():
     """Test the _construct_ptrue_prompt method."""
     prompt = "What is 2+2?"

--- a/uqlm/white_box/p_true.py
+++ b/uqlm/white_box/p_true.py
@@ -64,6 +64,11 @@ class PTrueScorer:
             else:
                 return np.nan
 
+        # First-token logprob unavailable -> undeterminable; return NaN to match
+        # the sentinel used above instead of implicitly returning None (which
+        # violates the -> float contract and breaks downstream numeric handling).
+        return np.nan
+
     @staticmethod
     def _construct_ptrue_prompt(original_prompt: str, original_response: str, sampled_responses: Optional[List[str]] = None) -> str:
         proposed_answers_text = ""


### PR DESCRIPTION
Fixes #417.

### Problem

`PTrueScorer._extract_ptrue_from_logprobs_result` is annotated `-> float` and uses
`np.nan` as the sentinel for an undeterminable score (the first token is neither "true"
nor "false"). When the first token has no `logprob` (missing key / `None`), the method
instead fell through to an implicit `return None`, which violates the `-> float` contract
and diverges from the `np.nan` sentinel used one branch over. The `None` then propagates
into `ptrue_scores` / `UQResult`, and `np.isnan(...)` on it raises `TypeError`.

### Fix

Return `np.nan` for the missing-logprob path, matching the unknown-token branch. One
line; no behavior change for tokens that do carry a logprob.

### Tests

Adds `test_extract_ptrue_from_logprobs_result_missing_logprob` to `tests/test_p_true.py`
(asserts the result is not `None` and is NaN). Verified against the real function:
`[{"token": "true"}]` (no `logprob`) returned `None` before this change and `NaN` after,
while the existing true / false / unknown cases are unchanged.
