### PR TITLE
fix(black_box): don't assign list.remove() return value (always None)

### DIFF
--- a/tests/test_consistency_use_best.py
+++ b/tests/test_consistency_use_best.py
@@ -1,0 +1,54 @@
+# Copyright 2025 CVS Health and/or one of its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock, patch
+
+
+def test_observed_consistency_use_best_returns_list():
+    """use_best=True must not crash — list.remove() returns None (regression).
+
+    list.remove() is an in-place operation that returns None. Using its return
+    value as the iteration target causes TypeError on the use_best=True path.
+    After the fix, candidates must be a list (the remaining responses minus
+    best_response).
+    """
+    from uqlm.black_box.consistency import ConsistencyScorer
+
+    with patch("uqlm.black_box.consistency.NLI"):
+        scorer = ConsistencyScorer(use_best=True)
+
+    mock_clusterer = MagicMock()
+    mock_clusterer.compute_response_probabilities.return_value = (
+        None,
+        [0.33, 0.33, 0.34],
+    )
+    mock_clusterer.evaluate.return_value = ("resp_B", None, None, None)
+    mock_clusterer.nli_scores = {}
+
+    with patch(
+        "uqlm.black_box.consistency.SemanticClusterer",
+        return_value=mock_clusterer,
+    ):
+        scorer.available_nli_scores = {}
+        scorer.nli = MagicMock()
+        scorer.nli.get_nli_results.return_value = {
+            "noncontradiction_score": 0.9,
+            "entailment_score": 0.8,
+        }
+        result = scorer._observed_consistency_i("resp_A", ["resp_B", "resp_C"])
+
+    # Key assertions: candidates is a list (not None) with best_response removed
+    assert isinstance(result["candidates"], list)
+    assert "resp_B" not in result["candidates"]
+    assert result["response"] == "resp_B"

--- a/uqlm/black_box/consistency.py
+++ b/uqlm/black_box/consistency.py
@@ -82,7 +82,8 @@ class ConsistencyScorer(SimilarityScorer):
             _, response_probabilities = self.clusterer.compute_response_probabilities(logprobs_results=None, num_responses=len(all_responses))
             best_response, _, _, _ = self.clusterer.evaluate(responses=all_responses, response_probabilities=response_probabilities)
 
-            candidates = all_responses.remove(best_response)
+            all_responses.remove(best_response)
+            candidates = all_responses
             self.available_nli_scores = self.clusterer.nli_scores
 
         nli_scores = {}


### PR DESCRIPTION
Fixes #420.

### Problem

`ConsistencyScorer._observed_consistency_i` crashes with `TypeError: 'NoneType' object
is not iterable` on every `use_best=True` path.

`list.remove()` modifies the list in-place and returns `None`. Using its return value as
the iteration target (`candidates = all_responses.remove(...)`) makes `candidates = None`,
so `for candidate in candidates:` immediately raises.

### Fix

Split into two statements — remove in-place, then assign the (now-modified) list to
`candidates`. No behavior change for the `use_best=False` path.

### Tests

Adds `tests/test_consistency_use_best.py` with a mocked regression test that exercises
the `use_best=True` path and asserts `candidates` is a list (not `None`) with
`best_response` removed.
