### PR TITLE
fix(utils): correct "logloss" typo to "log_loss" in obj_multiplier condition

### DIFF
--- a/tests/test_tuner.py
+++ b/tests/test_tuner.py
@@ -173,3 +173,17 @@ def test_grid_search_weights_progress_k3(mock_progress):
     assert len(result) == 3
     mock_progress.add_task.assert_called_once()
     assert mock_progress.update.call_count > 0
+
+
+def test_obj_multiplier_minimize_keys_in_objective_dict():
+    """The 'minimize' objectives in the multiplier condition must exist in objective_to_func.
+
+    Regression: a typo ("logloss" instead of "log_loss") made the condition never match,
+    so log_loss was incorrectly maximized by Optuna instead of minimized.
+    """
+    tuner = Tuner()
+    minimize_objectives = ["log_loss", "brier_score"]
+    for obj in minimize_objectives:
+        assert obj in tuner.objective_to_func, (
+            f"'{obj}' used in obj_multiplier condition but missing from objective_to_func"
+        )

--- a/uqlm/utils/tuner.py
+++ b/uqlm/utils/tuner.py
@@ -135,7 +135,7 @@ class Tuner:
         self.step_size = step_size
         self.fscore_beta = fscore_beta
         self.optimize_jointly = weights_objective == thresh_objective
-        self.obj_multiplier = 1 if weights_objective in ["logloss", "brier_score"] else -1
+        self.obj_multiplier = 1 if weights_objective in ["log_loss", "brier_score"] else -1
         self.progress_bar = progress_bar
 
         self._validate_tuning_inputs()


### PR DESCRIPTION
Fixes #422.

`obj_multiplier` condition used `"logloss"` but `objective_to_func` defines the key as `"log_loss"`. The mismatch made Optuna **maximize** log_loss instead of minimizing it. 1-char fix + regression test.