### PR TITLE
fix(generation): preserve prompt/response alignment on failed generations; bounded concurrency, retries, non-blocking sleeps

### DIFF
--- a/tests/test_responsegenerator.py
+++ b/tests/test_responsegenerator.py
@@ -330,7 +330,12 @@ async def test_ainvoke_with_top_logprobs_else_branch():
 
 @pytest.mark.asyncio
 async def test_ainvoke_with_top_logprobs_exception_handling():
-    """Test ainvoke_with_top_logprobs exception handling."""
+    """Test that ainvoke_with_top_logprobs raises the provider error when all attempts fail.
+
+    Regression guard for issue #416: the previous behavior swallowed the exception and
+    returned an empty (shorter-than-count) response list, which silently misaligned all
+    subsequent prompt/response pairs in the batch.
+    """
     mock_llm = MagicMock()
     generator = ResponseGenerator(llm=mock_llm, top_k_logprobs=5)
 
@@ -338,10 +343,146 @@ async def test_ainvoke_with_top_logprobs_exception_handling():
     mock_llm.ainvoke = AsyncMock(side_effect=Exception("Mocked exception"))
 
     messages = [HumanMessage(content="Hello")]
-    result = await generator.ainvoke_with_top_logprobs(messages=messages, count=1)
+    with pytest.raises(Exception, match="Mocked exception"):
+        await generator.ainvoke_with_top_logprobs(messages=messages, count=1)
 
-    # Assert that the result structure is still returned even after exceptions
-    assert "logprobs" in result
-    assert "responses" in result
-    assert result["logprobs"] == [None]
-    assert result["responses"] == []
+
+# ---------------------------------------------------------------------------
+# Regression tests for issue #416
+# ---------------------------------------------------------------------------
+
+
+def create_flaky_llm(failing_substring="Prompt 2", error=None):
+    """Mock BaseChatModel whose ainvoke always fails for prompts containing `failing_substring`."""
+    mock_llm = MagicMock(spec=BaseChatModel)
+    mock_llm.__str__ = lambda self: "other-provider"
+    mock_llm.temperature = 1
+
+    class FakeResult:
+        def __init__(self, content):
+            self.content = content
+            self.response_metadata = {"logprobs": {"content": [{"token": "x", "logprob": -0.1}]}}
+
+    async def flaky_ainvoke(messages, **kwargs):
+        text = messages[-1].content
+        if failing_substring in text:
+            raise error or RuntimeError("429 rate limited")
+        return FakeResult(f"Answer to: {text}")
+
+    mock_llm.ainvoke = flaky_ainvoke
+    return mock_llm
+
+
+@pytest.mark.asyncio
+async def test_all_logprob_attempts_fail_keeps_alignment():
+    """Regression test for issue #416: a prompt whose generation fails after all retries
+    must yield a correctly-sized placeholder instead of silently shortening the batch."""
+    generator = ResponseGenerator(llm=create_flaky_llm(), top_k_logprobs=15, max_retries=1)
+    generator._retry_base_delay = 0.001
+    prompts = ["Prompt 1", "Prompt 2", "Prompt 3"]
+    with pytest.warns(UserWarning, match="alignment is preserved"):
+        results = await generator.generate_responses(prompts=prompts, count=1)
+    data = results["data"]
+    assert len(data["response"]) == len(prompts)
+    assert data["response"][0] == "Answer to: Prompt 1"
+    assert data["response"][1] == "Unable to get response"
+    assert data["response"][2] == "Answer to: Prompt 3"
+
+
+@pytest.mark.asyncio
+async def test_failed_generation_reported_in_metadata():
+    """Failures exhausted of retries must appear in metadata['failures'] with index/prompt/error."""
+    generator = ResponseGenerator(llm=create_flaky_llm(), top_k_logprobs=15, max_retries=0)
+    with pytest.warns(UserWarning):
+        results = await generator.generate_responses(prompts=["Prompt 1", "Prompt 2"], count=1)
+    failures = results["metadata"]["failures"]
+    assert len(failures) == 1
+    assert failures[0]["prompt_index"] == 1
+    assert failures[0]["prompt"] == "Prompt 2"
+    assert "429 rate limited" in failures[0]["error"]
+
+
+@pytest.mark.asyncio
+async def test_retry_succeeds_after_transient_failure():
+    """A transiently failing call must be retried and succeed without placeholders."""
+    mock_llm = MagicMock(spec=BaseChatModel)
+    mock_llm.temperature = 1
+    attempts = {"n": 0}
+
+    async def transient_ainvoke(messages, **kwargs):
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            raise RuntimeError("transient 500")
+        return MagicMock(content="Recovered", response_metadata={})
+
+    mock_llm.ainvoke = transient_ainvoke
+    generator = ResponseGenerator(llm=mock_llm, max_retries=2)
+    generator._retry_base_delay = 0.001
+    results = await generator.generate_responses(prompts=["Prompt 1"], count=1)
+    assert results["data"]["response"] == ["Recovered"]
+    assert results["metadata"]["failures"] == []
+    assert attempts["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_concurrency_bounded_by_semaphore():
+    """No more than max_concurrency requests may be in flight simultaneously."""
+    mock_llm = MagicMock(spec=BaseChatModel)
+    mock_llm.temperature = 1
+    in_flight = {"now": 0, "peak": 0}
+
+    async def tracking_ainvoke(messages, **kwargs):
+        in_flight["now"] += 1
+        in_flight["peak"] = max(in_flight["peak"], in_flight["now"])
+        await asyncio.sleep(0.01)
+        in_flight["now"] -= 1
+        return MagicMock(content="ok", response_metadata={})
+
+    mock_llm.ainvoke = tracking_ainvoke
+    generator = ResponseGenerator(llm=mock_llm, max_concurrency=2)
+    prompts = [f"Prompt {i}" for i in range(8)]
+    await generator.generate_responses(prompts=prompts, count=1)
+    assert in_flight["peak"] <= 2
+
+
+@pytest.mark.asyncio
+async def test_no_blocking_sleep_in_async_paths(monkeypatch):
+    """time.sleep must not be called inside the async generation paths (issue #416)."""
+    import uqlm.utils.response_generator as rg_module
+
+    def fail_on_blocking_sleep(*args, **kwargs):
+        raise AssertionError("blocking time.sleep called inside async generation path")
+
+    monkeypatch.setattr(rg_module.time, "sleep", fail_on_blocking_sleep)
+    mock_async_api_call = create_mock_async_api_call()
+    generator = ResponseGenerator(llm=create_mock_llm(), max_calls_per_min=1000)
+    monkeypatch.setattr(generator, "_async_api_call", mock_async_api_call)
+    result = await generator.generate_responses(prompts=MOCKED_PROMPTS, count=1)
+    assert len(result["data"]["response"]) == len(MOCKED_PROMPTS)
+
+
+def test_empty_prompts_raises_value_error():
+    """An empty prompt list must raise a clear ValueError instead of a confusing range() error."""
+    generator = ResponseGenerator(llm=create_mock_llm())
+    with pytest.raises(ValueError, match="non-empty"):
+        asyncio.run(generator.generate_responses(prompts=[], count=1))
+
+
+def test_mixed_message_list_raises_value_error():
+    """A message list containing a non-BaseMessage item must raise ValueError, not UnboundLocalError."""
+    generator = ResponseGenerator(llm=create_mock_llm())
+    with pytest.raises(ValueError, match="BaseMessage"):
+        asyncio.run(generator.generate_responses(prompts=[[HumanMessage(content="hi"), "not a message"]], count=1))
+
+
+@pytest.mark.asyncio
+async def test_temperature_missing_attribute_ok(monkeypatch):
+    """Custom models without a `temperature` attribute must not crash generate_responses."""
+    mock_llm = MagicMock(spec=BaseChatModel)
+    # spec=BaseChatModel does not define `temperature`; ensure attribute access is guarded
+    del mock_llm.temperature
+    mock_llm.ainvoke = AsyncMock(return_value=MagicMock(content="ok", response_metadata={}))
+    generator = ResponseGenerator(llm=mock_llm)
+    result = await generator.generate_responses(prompts=["Prompt 1"], count=1)
+    assert result["data"]["response"] == ["ok"]
+    assert result["metadata"]["temperature"] is None

--- a/uqlm/utils/response_generator.py
+++ b/uqlm/utils/response_generator.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import itertools
+import random
 import time
 import warnings
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
@@ -24,6 +25,8 @@ from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
 from uqlm.utils.warn import beta_warning, deprecation_warning
 
+
+FAILED_RESPONSE = "Unable to get response"
 
 generator_type_to_progress_msg = {
     "judge": "Scoring responses with LLM-as-a-Judge",
@@ -37,7 +40,7 @@ generator_type_to_progress_msg = {
 
 
 class ResponseGenerator:
-    def __init__(self, llm: BaseChatModel = None, max_calls_per_min: Optional[int] = None, use_n_param: bool = False, top_k_logprobs: Optional[int] = None, structured_response: Optional[Any] = None, output_extractor: Optional[Any] = None) -> None:
+    def __init__(self, llm: BaseChatModel = None, max_calls_per_min: Optional[int] = None, use_n_param: bool = False, top_k_logprobs: Optional[int] = None, structured_response: Optional[Any] = None, output_extractor: Optional[Any] = None, max_concurrency: Optional[int] = 16, max_retries: int = 3) -> None:
         """
         Class for generating data from a provided set of prompts
 
@@ -59,6 +62,14 @@ class ResponseGenerator:
 
         output_extractor : callable, default=None
             A user-defined function that is called on the output of an llm with structured output to extract the response. Only used if `structured_response` is not None.
+
+        max_concurrency : int, default=16
+            Maximum number of generation requests that may be in flight simultaneously. Set to None
+            to fire all requests at once (not recommended for large prompt sets).
+
+        max_retries : int, default=3
+            Number of times a failed generation request is retried with exponential backoff before
+            a placeholder response is recorded for that prompt. Set to 0 to disable retries.
         """
         self.llm = llm
         self.use_n_param = use_n_param
@@ -70,6 +81,11 @@ class ResponseGenerator:
         self.top_k_logprobs = top_k_logprobs
         self.structured_response = structured_response
         self.output_extractor = output_extractor
+        self.max_concurrency = max_concurrency
+        self.max_retries = max_retries
+        self._retry_base_delay = 1.0
+        self._semaphore = None
+        self._failures: List[Dict[str, Any]] = []
 
         self._validate_structured_output_parameters()
 
@@ -118,23 +134,45 @@ class ResponseGenerator:
                     The count of prompts used in the generation process.
                 'system_prompt' : str
                     The system prompt used for generating responses
+                'failures' : list
+                    A list of dictionaries describing prompts whose generation failed after all
+                    retries. Each entry contains 'prompt_index', 'prompt', and 'error'. Failed
+                    prompts receive a placeholder response so that prompt/response alignment is
+                    always preserved.
         """
         assert isinstance(self.llm, BaseChatModel), """
             llm must be an instance of langchain_core.language_models.chat_models.BaseChatModel
         """
+        if not prompts:
+            raise ValueError("prompts must be a non-empty list")
+        self._validate_prompts(prompts)
         if any(isinstance(prompt, list) and all(isinstance(item, BaseMessage) for item in prompt) for prompt in prompts):
             beta_warning("Use of BaseMessage in prompts argument is in beta. Please use it with caution as it may change in future releases.")
 
-        if self.llm.temperature == 0:
+        temperature = getattr(self.llm, "temperature", None)
+        if temperature == 0:
             assert count == 1, "temperature must be greater than 0 if count > 1"
         self._update_count(count)
         self.system_message = None if not system_prompt else SystemMessage(system_prompt)
+        self._semaphore = asyncio.Semaphore(self.max_concurrency) if self.max_concurrency else None
+        self._failures = []
 
         generations, duplicated_prompts = await self._generate_in_batches(prompts=prompts, progress_bar=progress_bar)
 
         responses = generations["responses"]
         logprobs = generations["logprobs"]
-        return {"data": {"prompt": self._enforce_strings(duplicated_prompts), "response": self._enforce_strings(responses)}, "metadata": {"system_prompt": system_prompt, "temperature": self.llm.temperature, "count": self.count, "logprobs": logprobs}}
+        expected = len(prompts) * self.count
+        if len(responses) != expected:
+            raise RuntimeError(f"Response alignment invariant violated: expected {expected} responses ({len(prompts)} prompts x count={self.count}), got {len(responses)}. Please report this at https://github.com/cvs-health/uqlm/issues")
+        return {"data": {"prompt": self._enforce_strings(duplicated_prompts), "response": self._enforce_strings(responses)}, "metadata": {"system_prompt": system_prompt, "temperature": temperature, "count": self.count, "logprobs": logprobs, "failures": list(self._failures)}}
+
+    @staticmethod
+    def _validate_prompts(prompts: List[Union[str, List[BaseMessage]]]) -> None:
+        """Raise a clear ValueError if any prompt is neither a string nor a list of BaseMessage."""
+        for prompt in prompts:
+            valid = isinstance(prompt, str) or (isinstance(prompt, list) and len(prompt) > 0 and all(isinstance(item, BaseMessage) for item in prompt))
+            if not valid:
+                raise ValueError("prompts must be list of strings or list of lists of BaseMessage instances. For support with LangChain BaseMessage usage, refer here: https://python.langchain.com/docs/concepts/messages")
 
     def _validate_structured_output_parameters(self) -> None:
         if self.structured_response and not self.output_extractor:
@@ -142,14 +180,41 @@ class ResponseGenerator:
         if self.output_extractor and not self.structured_response:
             raise ValueError("If `output_extractor` is specified, `structured_response` must also be specified.")
 
-    def _create_tasks(self, prompts: List[Union[str, List[BaseMessage]]]) -> Tuple[List[Any], List[str]]:
+    def _create_tasks(self, prompts: List[Union[str, List[BaseMessage]]], start_index: int = 0) -> Tuple[List[Any], List[str]]:
         """
         Creates a list of async tasks and returns duplicated prompt list
         with each prompt duplicated `count` times
         """
         duplicated_prompts = [prompt for prompt, i in itertools.product(prompts, range(self.count))]
-        tasks = [self._async_api_call(prompt=prompt, count=1) for prompt in duplicated_prompts]
+        tasks = [self._call_with_retry(prompt=prompt, count=1, task_index=start_index + i) for i, prompt in enumerate(duplicated_prompts)]
         return tasks, duplicated_prompts
+
+    async def _call_with_retry(self, prompt: Union[str, List[BaseMessage]], count: int = 1, task_index: Optional[int] = None) -> Dict[str, Any]:
+        """
+        Wraps `_async_api_call` with bounded concurrency and exponential-backoff retries.
+
+        If every attempt fails, a correctly-sized placeholder result is returned and the
+        failure is recorded in `self._failures`, so the batch is never silently shortened
+        and prompt/response alignment is preserved.
+        """
+        last_error = None
+        for attempt in range(self.max_retries + 1):
+            try:
+                if self._semaphore:
+                    async with self._semaphore:
+                        return await self._async_api_call(prompt=prompt, count=count)
+                return await self._async_api_call(prompt=prompt, count=count)
+            except Exception as e:  # noqa: BLE001 - provider errors are arbitrary
+                last_error = e
+                if attempt < self.max_retries:
+                    delay = self._retry_base_delay * (2**attempt) * random.uniform(0.5, 1.0)
+                    await asyncio.sleep(delay)
+        warnings.warn(f"Generation failed after {self.max_retries + 1} attempts for prompt index {task_index} ({type(last_error).__name__}: {last_error}). A placeholder response is used so prompt/response alignment is preserved; see metadata['failures'].")
+        self._failures.append({"prompt_index": task_index, "prompt": str(prompt), "error": f"{type(last_error).__name__}: {last_error}"})
+        if self.progress_bar:
+            for _ in range(count):
+                self.progress_bar.update(self.progress_task, advance=1)
+        return {"logprobs": [None] * count, "responses": [FAILED_RESPONSE] * count}
 
     def _update_count(self, count: int) -> None:
         """Updates self.count parameter and self.llm as necessary"""
@@ -178,19 +243,24 @@ class ResponseGenerator:
             if batch_idx == len(prompts_partition) - 1:
                 check_batch_time = False
             await self._process_batch(prompt_batch, duplicated_prompts, generations, check_batch_time)
-        time.sleep(0.1)
+        if self.progress_bar:
+            await asyncio.sleep(0.1)  # cosmetic pause so the progress bar finishes rendering
         return generations, duplicated_prompts
 
     async def _process_batch(self, prompt_batch: List[Union[str, List[BaseMessage]]], duplicated_prompts: List[str], generations: Dict[str, List[Any]], check_batch_time: bool) -> None:
         """Process a single batch of prompts"""
         start = time.time()
         # generate responses for current batch
-        tasks, duplicated_batch_prompts = self._create_tasks(prompt_batch)
+        tasks, duplicated_batch_prompts = self._create_tasks(prompt_batch, start_index=len(duplicated_prompts))
         generations_batch = await asyncio.gather(*tasks)
         responses_batch, logprobs_batch = [], []
         for g in generations_batch:
             responses_batch.extend(g["responses"])
             logprobs_batch.extend(g["logprobs"])
+
+        # invariant: a failed generation must never silently shorten the batch
+        if len(responses_batch) != len(duplicated_batch_prompts):
+            raise RuntimeError(f"Response alignment invariant violated in batch: expected {len(duplicated_batch_prompts)} responses, got {len(responses_batch)}. Please report this at https://github.com/cvs-health/uqlm/issues")
 
         # extend lists to include current batch
         duplicated_prompts.extend(duplicated_batch_prompts)
@@ -198,18 +268,17 @@ class ResponseGenerator:
         generations["logprobs"].extend(logprobs_batch)
         stop = time.time()
 
-        # pause if needed
+        # pause if needed (non-blocking so other event-loop work can proceed)
         if (stop - start < 60) and check_batch_time:
-            time.sleep(61 - stop + start)
+            await asyncio.sleep(61 - stop + start)
 
     async def _async_api_call(self, prompt: Union[str, List[BaseMessage]], count: int = 1) -> Dict[str, Any]:
         """Generates responses asynchronously using an RunnableSequence object"""
         if isinstance(prompt, str):
             system_message = SystemMessage("You are a helpful assistant.") if not self.system_message else self.system_message
             messages = [system_message, HumanMessage(prompt)]
-        elif isinstance(prompt, list):
-            if all(isinstance(item, BaseMessage) for item in prompt):
-                messages = prompt if not self.system_message else [self.system_message] + prompt
+        elif isinstance(prompt, list) and all(isinstance(item, BaseMessage) for item in prompt):
+            messages = prompt if not self.system_message else [self.system_message] + prompt
         else:
             raise ValueError("prompts must be list of strings or list of lists of BaseMessage instances. For support with LangChain BaseMessage usage, refer here: https://python.langchain.com/docs/concepts/messages")
 
@@ -234,7 +303,12 @@ class ResponseGenerator:
         return result_dict
 
     async def ainvoke_with_top_logprobs(self, messages: List[BaseMessage], count: int) -> Any:
-        """Use ainvoke method with top_logprobs configured"""
+        """Use ainvoke method with top_logprobs configured
+
+        Raises the underlying provider error if every attempt to fetch logprobs fails, so that
+        callers (e.g. the retry wrapper) can react instead of silently receiving a shortened
+        response list that would misalign prompts and responses (issue #416).
+        """
         logprobs = [None] * count
         result = None
         if "openai" in self.llm.__str__().lower():
@@ -246,13 +320,8 @@ class ResponseGenerator:
             try:
                 result = await self.llm.ainvoke(messages, logprobs=True, top_logprobs=self.top_k_logprobs)
             except Exception:
-                try:
-                    self.llm.logprobs = self.top_k_logprobs
-                    result = await self.llm.ainvoke(messages)
-                except Exception:
-                    pass
-        if result is None:  # if all attempts fail
-            return {"logprobs": [None] * count, "responses": []}
+                self.llm.logprobs = self.top_k_logprobs
+                result = await self.llm.ainvoke(messages)
         logprobs = self._extract_logprobs(logprobs=logprobs, result=result, count=count)
         return {"logprobs": logprobs, "responses": [result.content]}
 


### PR DESCRIPTION
## Root Cause

In `ResponseGenerator.ainvoke_with_top_logprobs`, when every attempt to fetch logprobs fails, the method swallowed the exception and returned `{"responses": []}` — a response list *shorter than `count`*. `_process_batch` extends flat lists, so the batch silently shrank and **every response after the failed prompt was paired with the wrong prompt** (scores look normal, they're just attributed to the wrong prompts). Two related reliability problems lived in the same methods: unbounded concurrency with no retry (one exception discarded the whole run), and blocking `time.sleep` inside coroutines freezing the event loop.

Reproduced locally with a mock provider that always fails for one prompt: `len(responses) == 2` for 3 prompts, with prompt 2 receiving prompt 3's answer.

## Fix

- **Alignment**: `ainvoke_with_top_logprobs` now raises the underlying provider error instead of returning a shortened list. A new `_call_with_retry` wrapper converts exhausted failures into a correctly-sized placeholder (`"Unable to get response"`) with a `UserWarning`, and records them in `metadata["failures"]` (`prompt_index`/`prompt`/`error`) — partial failures never discard successful generations.
- **Invariant checks** (defense in depth): `len(responses) == count × len(prompts)` is enforced after every batch (`_process_batch`) and on the final result (`generate_responses`), so any future path that shortens a batch fails loudly instead of silently misaligning.
- **Bounded concurrency + retries**: `max_concurrency=16` (configurable, `None` = old fire-all-at-once behavior) via `asyncio.Semaphore`; `max_retries=3` (configurable, `0` disables) with exponential backoff + jitter.
- **Non-blocking sleeps**: the rate-limit pause (`time.sleep(61 - ...)`) and the cosmetic progress-bar pause are now `await asyncio.sleep(...)`; the cosmetic pause only runs when a progress bar is active.
- **Input validation**: empty prompt list → clear `ValueError` (was `range() arg 3 must not be zero`); message list containing a non-`BaseMessage` → `ValueError` (was `UnboundLocalError`); `llm.temperature` read via `getattr` (custom models without the attribute no longer crash).

Note on scope: the other ~20 cosmetic `time.sleep(0.1)` calls live in other scorer classes across the codebase; left them out to keep this PR focused on `ResponseGenerator` — happy to do a follow-up.

## Test

- [x] `test_all_logprob_attempts_fail_keeps_alignment` — regression test for the reported misalignment (issue #416)
- [x] `test_failed_generation_reported_in_metadata` — failure report contents
- [x] `test_retry_succeeds_after_transient_failure` — transient failure recovers, no placeholder
- [x] `test_concurrency_bounded_by_semaphore` — peak in-flight ≤ `max_concurrency`
- [x] `test_no_blocking_sleep_in_async_paths` — `time.sleep` monkeypatched to fail if called
- [x] `test_empty_prompts_raises_value_error`, `test_mixed_message_list_raises_value_error`, `test_temperature_missing_attribute_ok` — edge cases
- [x] Updated `test_ainvoke_with_top_logprobs_exception_handling` — the old assertion locked in the buggy `responses == []` behavior; it now asserts the provider error propagates
- [x] Full `tests/test_responsegenerator.py`: **22 passed**; adjacent suites (`test_top_logprobs`, `test_llmjudge`, `test_grader`, `test_question_generator`, `test_p_true`): pass (3 failures in `test_sampled_logprobs` are HuggingFace model-download timeouts on my machine, unrelated to this change)
- [x] `ruff check` + `ruff format --check` clean

## Diff scope

2 files, +237/−27 (`uqlm/utils/response_generator.py`, `tests/test_responsegenerator.py`)

## AI Disclosure

AI assistance was used for drafting the implementation and tests; I reproduced the bug locally before patching, reviewed every line, and verified behavior with the test suite above.
