### PR TITLE
Enforce async test execution in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,4 +40,4 @@ jobs:
         run: uv sync --group test
 
       - name: Run tests
-        run: uv run pytest -v
+        run: uv run pytest -v -m "not integration"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,10 +90,13 @@ packages = ["uqlm"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-reruns = 3
-reruns_delay = 2.0
 markers = [
-    "asyncio"
+    "asyncio",
+    "integration: tests exercising subprocesses or external services; retried on failure in CI"
+]
+filterwarnings = [
+    "error:coroutine .* was never awaited:RuntimeWarning",
+    "error::pytest.PytestUnraisableExceptionWarning"
 ]
 
 [tool.ruff]

--- a/tests/test_async_hygiene.py
+++ b/tests/test_async_hygiene.py
@@ -1,0 +1,37 @@
+# Copyright 2025 CVS Health and/or one of its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ast
+import pathlib
+
+
+def _base_names(cls: ast.ClassDef) -> set:
+    """Collect the terminal names of a class's bases (e.g. unittest.TestCase -> TestCase)."""
+    return {getattr(b, "attr", getattr(b, "id", "")) for b in cls.bases}
+
+
+def test_no_async_tests_on_plain_testcase():
+    """async def test_* methods on a plain unittest.TestCase are returned as un-awaited
+    coroutines by the runner and never execute; such classes must derive from
+    unittest.IsolatedAsyncioTestCase instead."""
+    offenders = []
+    for f in pathlib.Path(__file__).parent.rglob("test_*.py"):
+        tree = ast.parse(f.read_text(encoding="utf-8"))
+        for cls in [n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)]:
+            bases = _base_names(cls)
+            if "TestCase" in bases and "IsolatedAsyncioTestCase" not in bases:
+                for fn in cls.body:
+                    if isinstance(fn, ast.AsyncFunctionDef) and fn.name.startswith("test"):
+                        offenders.append(f"{f.name}::{cls.name}.{fn.name}")
+    assert not offenders, f"async tests on plain unittest.TestCase do not execute; use IsolatedAsyncioTestCase: {offenders}"

--- a/tests/test_entailment_classifier.py
+++ b/tests/test_entailment_classifier.py
@@ -15,17 +15,16 @@
 import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 import numpy as np
-import pandas as pd
-import asyncio
+
 from rich.progress import Progress
 
 from langchain_core.language_models.chat_models import BaseChatModel
-from langchain_core.messages import HumanMessage, SystemMessage, AIMessage
+from langchain_core.messages import AIMessage
 
-from uqlm.nli.entailment import EntailmentClassifier, SYSTEM_PROMPT, STR_SCORE_MAP
+from uqlm.nli.entailment import EntailmentClassifier, SYSTEM_PROMPT
 
 
-class TestEntailmentClassifier(unittest.TestCase):
+class TestEntailmentClassifier(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         # Create a mock LLM for testing
         self.mock_llm = MagicMock(spec=BaseChatModel)
@@ -197,9 +196,7 @@ class TestEntailmentClassifier(unittest.TestCase):
         """Test the judge_entailment method"""
         # Setup mocks
         mock_construct.return_value = ["Prompt 1", "Prompt 2"]
-        mock_evaluate.side_effect = [asyncio.Future(), asyncio.Future()]
-        mock_evaluate.side_effect[0].set_result("Yes")
-        mock_evaluate.side_effect[1].set_result("No")
+        mock_evaluate.side_effect = ["Yes", "No"]
         mock_extract.return_value = [1.0, 0.0]
 
         # Call the method
@@ -214,18 +211,22 @@ class TestEntailmentClassifier(unittest.TestCase):
         expected_result = {"judge_prompts": ["Prompt 1", "Prompt 2"], "judge_responses": ["Yes", "No"], "scores": [1.0, 0.0]}
         self.assertEqual(result, expected_result)
 
-        # Test with retry logic
-        mock_extract.side_effect = [[1.0, np.nan], [0.0]]  # First call has a NaN, second call succeeds
-        mock_evaluate.reset_mock()
-        mock_evaluate.side_effect = [asyncio.Future(), asyncio.Future(), asyncio.Future()]
-        mock_evaluate.side_effect[0].set_result("Yes")
-        mock_evaluate.side_effect[1].set_result("Unclear")
-        mock_evaluate.side_effect[2].set_result("No")
+    # Known defect in the retry path (re-query uses the wrong prompts and result
+    # indexing); fix is tracked separately. Remove the marker when the fix lands.
+    @unittest.expectedFailure
+    @patch.object(EntailmentClassifier, "_construct_prompts")
+    @patch.object(EntailmentClassifier, "_evaluate_claim_response_pair")
+    async def test_judge_entailment_retry(self, mock_evaluate, mock_construct):
+        """A failed extraction must be retried by re-querying the original judge prompt"""
+        mock_construct.return_value = ["Prompt 1", "Prompt 2"]
+        # Second response is unparseable, so the second prompt must be retried once
+        mock_evaluate.side_effect = ["Yes", "I think so", "No"]
 
         result = await self.classifier.judge_entailment(premises=["Premise 1", "Premise 2"], hypotheses=["Hypothesis 1", "Hypothesis 2"], retries=1)
 
-        # Check that retry was attempted
         self.assertEqual(mock_evaluate.call_count, 3)  # Initial 2 calls + 1 retry
+        self.assertEqual(mock_evaluate.call_args_list[2].args[0], "Prompt 2")
+        self.assertEqual(result["scores"], [1.0, 0.0])
 
     @patch.object(EntailmentClassifier, "_flatten_inputs")
     @patch.object(EntailmentClassifier, "judge_entailment")
@@ -234,8 +235,7 @@ class TestEntailmentClassifier(unittest.TestCase):
         """Test the evaluate_claim_entailment method"""
         # Setup mocks
         mock_flatten.return_value = (["Flat Response 1", "Flat Response 2"], ["Flat Claim 1", "Flat Claim 2"], [(0, 0, 0), (0, 1, 0)], [(2, 1)])
-        mock_judge.return_value = asyncio.Future()
-        mock_judge.return_value.set_result({"judge_prompts": ["Prompt 1", "Prompt 2"], "judge_responses": ["Yes", "No"], "scores": [1.0, 0.0]})
+        mock_judge.return_value = {"judge_prompts": ["Prompt 1", "Prompt 2"], "judge_responses": ["Yes", "No"], "scores": [1.0, 0.0]}
         mock_format.return_value = [np.array([[1.0], [0.0]])]
 
         # Call the method

--- a/tests/test_entailment_classifier.py
+++ b/tests/test_entailment_classifier.py
@@ -15,7 +15,6 @@
 import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 import numpy as np
-
 from rich.progress import Progress
 
 from langchain_core.language_models.chat_models import BaseChatModel
@@ -25,6 +24,8 @@ from uqlm.nli.entailment import EntailmentClassifier, SYSTEM_PROMPT
 
 
 class TestEntailmentClassifier(unittest.IsolatedAsyncioTestCase):
+    # IsolatedAsyncioTestCase is required: async test methods on a plain TestCase are
+    # never awaited and pass vacuously.
     def setUp(self):
         # Create a mock LLM for testing
         self.mock_llm = MagicMock(spec=BaseChatModel)
@@ -54,6 +55,12 @@ class TestEntailmentClassifier(unittest.IsolatedAsyncioTestCase):
         # Test no match
         self.assertTrue(np.isnan(self.classifier._extract_single_score("Maybe, it's unclear")))
         self.assertTrue(np.isnan(self.classifier._extract_single_score("I'm unsure")))
+
+    def test_extract_single_score_case_insensitive_fallback(self):
+        """Regression: the substring fallback compared lowercase keywords against raw text,
+        so capitalized mid-sentence answers like 'The answer is Yes.' returned NaN."""
+        self.assertEqual(self.classifier._extract_single_score("The answer is Yes."), 1.0)
+        self.assertEqual(self.classifier._extract_single_score("I believe the answer is No."), 0.0)
 
     def test_extract_scores(self):
         """Test the _extract_scores method"""
@@ -194,7 +201,7 @@ class TestEntailmentClassifier(unittest.IsolatedAsyncioTestCase):
     @patch.object(EntailmentClassifier, "_evaluate_claim_response_pair")
     async def test_judge_entailment(self, mock_evaluate, mock_extract, mock_construct):
         """Test the judge_entailment method"""
-        # Setup mocks
+        # Setup mocks (patching an async method yields an AsyncMock, so plain values suffice)
         mock_construct.return_value = ["Prompt 1", "Prompt 2"]
         mock_evaluate.side_effect = ["Yes", "No"]
         mock_extract.return_value = [1.0, 0.0]
@@ -211,29 +218,45 @@ class TestEntailmentClassifier(unittest.IsolatedAsyncioTestCase):
         expected_result = {"judge_prompts": ["Prompt 1", "Prompt 2"], "judge_responses": ["Yes", "No"], "scores": [1.0, 0.0]}
         self.assertEqual(result, expected_result)
 
-    # Known defect in the retry path (re-query uses the wrong prompts and result
-    # indexing); fix is tracked separately. Remove the marker when the fix lands.
-    @unittest.expectedFailure
-    @patch.object(EntailmentClassifier, "_construct_prompts")
-    @patch.object(EntailmentClassifier, "_evaluate_claim_response_pair")
-    async def test_judge_entailment_retry(self, mock_evaluate, mock_construct):
-        """A failed extraction must be retried by re-querying the original judge prompt"""
-        mock_construct.return_value = ["Prompt 1", "Prompt 2"]
-        # Second response is unparseable, so the second prompt must be retried once
-        mock_evaluate.side_effect = ["Yes", "I think so", "No"]
+        # Test with retry logic
+        mock_extract.side_effect = [[1.0, np.nan], [0.0]]  # First call has a NaN, second call succeeds
+        mock_evaluate.reset_mock()
+        mock_evaluate.side_effect = ["Yes", "Unclear", "No"]
 
         result = await self.classifier.judge_entailment(premises=["Premise 1", "Premise 2"], hypotheses=["Hypothesis 1", "Hypothesis 2"], retries=1)
 
+        # Check that retry was attempted
         self.assertEqual(mock_evaluate.call_count, 3)  # Initial 2 calls + 1 retry
-        self.assertEqual(mock_evaluate.call_args_list[2].args[0], "Prompt 2")
-        self.assertEqual(result["scores"], [1.0, 0.0])
+
+    async def test_retry_requeries_original_prompt(self):
+        """Regression: the retry path sent DataFrame column names to the LLM as prompts, then
+        crashed indexing the gathered list. It must re-query the ORIGINAL prompt of each
+        failed pair and merge the recovered score."""
+        self.mock_llm.ainvoke.side_effect = [AIMessage(content="I think so"), AIMessage(content="Yes")]
+
+        result = await self.classifier.judge_entailment(premises=["The dog is barking."], hypotheses=["The animal makes noise."], retries=2)
+
+        self.assertEqual(self.mock_llm.ainvoke.call_count, 2)
+        original_prompt = self.mock_llm.ainvoke.call_args_list[0][0][0][1].content
+        retried_prompt = self.mock_llm.ainvoke.call_args_list[1][0][0][1].content
+        self.assertEqual(retried_prompt, original_prompt)
+        self.assertEqual(result["scores"], [1.0])
+        self.assertEqual(result["judge_responses"], ["Yes"])
+
+    def test_format_result_arrays_accepts_nan(self):
+        """Regression: the entailment matrix used dtype=int, which cannot hold the NaN left by
+        pairs whose extraction failed after all retries."""
+        result_matrices = self.classifier._format_result_arrays(flat_predictions=[1.0, np.nan], indices=[(0, 0, 0), (0, 1, 0)], shapes=[(2, 1)])
+        self.assertEqual(result_matrices[0].shape, (2, 1))
+        self.assertEqual(result_matrices[0][0, 0], 1.0)
+        self.assertTrue(np.isnan(result_matrices[0][1, 0]))
 
     @patch.object(EntailmentClassifier, "_flatten_inputs")
     @patch.object(EntailmentClassifier, "judge_entailment")
     @patch.object(EntailmentClassifier, "_format_result_arrays")
     async def test_evaluate_claim_entailment(self, mock_format, mock_judge, mock_flatten):
         """Test the evaluate_claim_entailment method"""
-        # Setup mocks
+        # Setup mocks (patching an async method yields an AsyncMock, so plain values suffice)
         mock_flatten.return_value = (["Flat Response 1", "Flat Response 2"], ["Flat Claim 1", "Flat Claim 2"], [(0, 0, 0), (0, 1, 0)], [(2, 1)])
         mock_judge.return_value = {"judge_prompts": ["Prompt 1", "Prompt 2"], "judge_responses": ["Yes", "No"], "scores": [1.0, 0.0]}
         mock_format.return_value = [np.array([[1.0], [0.0]])]

--- a/uqlm/nli/entailment.py
+++ b/uqlm/nli/entailment.py
@@ -90,15 +90,16 @@ class EntailmentClassifier:
 
             # If ANY failures exist, retry
             if len(score_failures) > 0:
-                # Get all failure indices
-                failure_indices = set(score_failures.index)
+                # Re-query the LLM with the original prompts of the failed pairs
+                failure_indices = list(score_failures.index)
 
-                tasks_tmp = [self._evaluate_claim_response_pair(prompt) for prompt in list(df.loc[list(failure_indices)])]
+                tasks_tmp = [self._evaluate_claim_response_pair(prompt) for prompt in df.loc[failure_indices, "judge_prompts"]]
                 response_tmp = await asyncio.gather(*tasks_tmp)
 
-                retry_data = self._extract_scores(response_tmp["data"]["response"])
+                retry_data = self._extract_scores(response_tmp)
 
-                df.loc[list(failure_indices), "scores"] = retry_data
+                df.loc[failure_indices, "judge_responses"] = response_tmp
+                df.loc[failure_indices, "scores"] = retry_data
 
             # Exit if no more failures
             if len(score_failures) == 0:
@@ -165,7 +166,7 @@ class EntailmentClassifier:
 
         for word, score in STR_SCORE_MAP.items():
             # fallback: substring search
-            if word in response_text:
+            if word in clean_text:
                 return score
 
         return np.nan
@@ -206,7 +207,8 @@ class EntailmentClassifier:
         """
         entailment_matrices = []
         for i, shape in enumerate(shapes):
-            entail_matrix = np.zeros(shape, dtype=int)
+            # float dtype: residual extraction failures are NaN, which an int matrix cannot hold
+            entail_matrix = np.zeros(shape, dtype=float)
             for pred, (idx, j, k) in zip(flat_predictions, indices):
                 if idx == i:
                     entail_matrix[j, k] = pred


### PR DESCRIPTION
## Description

Async test methods defined on a plain `unittest.TestCase` don't actually run —
the runner can't execute them, so they pass without ever executing their body.
`tests/test_entailment_classifier.py` had this problem: its async tests were
green but had never run. Python warns about it ("coroutine was never awaited"),
but nothing treated the warning as a failure.

This PR:

1. Migrates the affected test class to `unittest.IsolatedAsyncioTestCase` so
   its async tests actually execute, and repairs their mock setup (bugs in the
   setup had gone unnoticed because the code never ran).
2. Adds two safeguards so this can't come back:
   - pytest now turns the "coroutine was never awaited" warning into an error
     (two `filterwarnings` entries — the warning surfaces during garbage
     collection, so `PytestUnraisableExceptionWarning` must be an error too);
   - a new test (`tests/test_async_hygiene.py`) scans the test suite and fails
     if any async test sits on a plain `TestCase`.
3. Removes the global `reruns = 3` pytest setting, so a failing unit test fails
   on the first run instead of being retried into green. An `integration`
   marker is registered, and the CI run now excludes it; retries will be
   reintroduced for integration-marked tests only, in a follow-up PR that adds
   the first such tests.
4. Fixes a defect in the entailment retry path that the newly-executing tests
   exposed: failed score extractions were retried with the wrong prompts and
   the retry results were mis-indexed; the yes/no fallback was also
   case-sensitive, and the result matrix could not hold NaN for residual
   failures. Note: the same fix exists in #413 with identical file content, so
   the two PRs merge cleanly in either order.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Dependency update

## Checklist
- [x] Tests added or updated for all changed behavior
- [x] Docstrings updated for any new or modified public API
- [x] Type annotations added for any new or modified functions
- [x] `ruff check` and `ruff format` pass locally

Verified locally: full suite of unit tests passed.