### PR TITLE
Limit memory, CPU, and file size when executing generated code

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,3 +41,6 @@ jobs:
 
       - name: Run tests
         run: uv run pytest -v -m "not integration"
+
+      - name: Run integration tests
+        run: uv run pytest -v -m integration --reruns 3 --reruns-delay 2

--- a/docs/source/scorer_definitions/code_generation/index.rst
+++ b/docs/source/scorer_definitions/code_generation/index.rst
@@ -5,6 +5,17 @@ Code-Generation Scorers
 
 Code-generation uncertainty quantification uses :class:`CodeGenUQ` to score generated code. These scorers either reuse existing short-form UQ methods or adapt black-box consistency scoring to code by comparing structural similarity or functional equivalence across sampled generations.
 
+.. warning::
+
+   Benchmarking generated code against test cases (e.g., with
+   ``uqlm.code.code_evaluation.evaluate_python_code``, as in the
+   code-generation demo notebook) executes model-generated code in a
+   subprocess with configurable resource limits (memory, CPU time, and file
+   size, enforced on POSIX systems) and a wall-clock timeout. This is
+   process-level isolation, **not** a security sandbox; do not run untrusted
+   code from sources you don't control outside an isolated environment
+   (container/VM).
+
 **Key Characteristics:**
 
 - **White-box compatibility:** Token-probability scorers are identical to the corresponding :doc:`white-box scorers <../white_box/index>`.

--- a/examples/codegen_demo.ipynb
+++ b/examples/codegen_demo.ipynb
@@ -67,6 +67,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "d15ed18f",
+   "source": "<div style=\"background-color: rgba(200, 150, 0, 0.1); padding: 15px; border-radius: 8px; margin-bottom: 20px; border: 1px solid rgba(200, 150, 0, 0.3); max-width: 97.5%; overflow-wrap: break-word;\">\n  <p style=\"margin: 0; font-size: 15px; line-height: 1.6\">\n    <strong>⚠️ Code execution notice:</strong> Section 3 of this demo grades LLM-generated code by executing it with\n    <code>uqlm.code.code_evaluation.evaluate_python_code</code>. The code runs in a subprocess with configurable resource limits\n    (memory, CPU time, and file size, enforced on POSIX systems) and a wall-clock timeout. This is process-level isolation,\n    <strong>not</strong> a security sandbox; do not run untrusted code from sources you don't control outside an isolated\n    environment (container/VM).\n  </p>\n</div>",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "e3621d39",

--- a/tests/test_code_evaluation_limits.py
+++ b/tests/test_code_evaluation_limits.py
@@ -1,0 +1,59 @@
+# Copyright 2025 CVS Health and/or one of its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import time
+
+import pytest
+
+from uqlm.code.code_evaluation import evaluate_python_code
+
+pytestmark = [pytest.mark.integration, pytest.mark.skipif(os.name != "posix", reason="resource limits are enforced via POSIX rlimits")]
+
+
+def _evaluate_single(code: str, expected_output: str, **kwargs) -> int:
+    result = evaluate_python_code(responses=[code], public_test_cases=[[{"input": "", "output": expected_output}]], metadata=[{}], **kwargs)
+    return result["unit_test_passed"][0]
+
+
+def test_normal_grading_passes_under_default_limits():
+    assert _evaluate_single("print(41 + 1)", "42") == 1
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="macOS does not enforce RLIMIT_AS/RLIMIT_DATA")
+def test_memory_limit_enforced():
+    """An 8 GiB allocation must raise MemoryError inside the subprocess instead of exhausting host memory."""
+    code = "try:\n    x = bytearray(8 * 1024**3)\n    print('ALLOCATED')\nexcept MemoryError:\n    print('CAPPED')"
+    assert _evaluate_single(code, "CAPPED") == 1
+
+
+def test_cpu_limit_kills_spinning_process():
+    """A busy loop must be killed at the CPU limit well before the wall-clock ceiling."""
+    code = "while True:\n    pass"
+    start = time.monotonic()
+    # timeout=15 keeps the per-test SIGALRM and the wall-clock kill far away, so
+    # only the 2-second CPU rlimit can stop the loop this quickly.
+    passed = _evaluate_single(code, "irrelevant", timeout=15, cpu_time_limit_seconds=2)
+    elapsed = time.monotonic() - start
+    assert passed == 0
+    assert elapsed < 10, f"spinning process survived past the CPU limit ({elapsed:.1f}s)"
+
+
+def test_file_size_limit_enforced(tmp_path):
+    """Writing past the file-size cap must raise OSError inside the subprocess."""
+    target = tmp_path / "big.bin"
+    code = f"try:\n    with open({str(target)!r}, 'wb') as f:\n        f.write(b'x' * (5 * 1024 * 1024))\n    print('WROTE')\nexcept OSError:\n    print('CAPPED')"
+    assert _evaluate_single(code, "CAPPED", max_file_size_bytes=1024**2) == 1
+    assert not target.exists() or target.stat().st_size <= 1024**2

--- a/uqlm/code/code_evaluation.py
+++ b/uqlm/code/code_evaluation.py
@@ -7,9 +7,54 @@ import html
 import subprocess
 
 
-def evaluate_python_code(responses: List[str], public_test_cases: List[Any], metadata: List[Any]) -> Dict[str, Any]:
+# Defaults for the resource limits applied to each evaluation subprocess.
+# Enforced via POSIX rlimits; on Windows the rlimits are unavailable and are
+# not applied (the wall-clock subprocess timeout still applies everywhere).
+DEFAULT_MEMORY_LIMIT_BYTES = 4 * 1024**3  # 4 GiB
+DEFAULT_CPU_TIME_LIMIT_SECONDS = 10
+DEFAULT_MAX_FILE_SIZE_BYTES = 1024**2  # 1 MiB
+
+
+def evaluate_python_code(responses: List[str], public_test_cases: List[Any], metadata: List[Any], timeout: int = 6, memory_limit_bytes: int = DEFAULT_MEMORY_LIMIT_BYTES, cpu_time_limit_seconds: int = DEFAULT_CPU_TIME_LIMIT_SECONDS, max_file_size_bytes: int = DEFAULT_MAX_FILE_SIZE_BYTES) -> Dict[str, Any]:
     """
     Evaluates all the Python responses against public test cases.
+
+    Each response is executed in a subprocess with resource limits (memory,
+    CPU time, and maximum file size) plus a hard wall-clock timeout. The
+    resource limits are enforced via POSIX rlimits: on Windows they are not
+    applied, and on macOS the kernel does not enforce memory (address-space)
+    rlimits, so only the CPU/file-size limits and the wall-clock timeout apply
+    there.
+
+    .. warning::
+        This utility executes model-generated code in a subprocess with
+        resource limits. It is **not** a security sandbox; do not run
+        untrusted code from sources you don't control outside an isolated
+        environment (container/VM).
+
+    Parameters
+    ----------
+    responses : List[str]
+        Model responses containing candidate Python code.
+
+    public_test_cases : List[Any]
+        Test cases (list of dicts or JSON string) for each response.
+
+    metadata : List[Any]
+        Per-response metadata (dict or JSON string); may include "func_name" for call-based grading.
+
+    timeout : int, default=6
+        Per-test wall-clock timeout in seconds; the subprocess is hard-killed at timeout + 5 seconds.
+
+    memory_limit_bytes : int, default=4 GiB
+        Maximum memory available to the evaluation subprocess (POSIX only).
+
+    cpu_time_limit_seconds : int, default=10
+        Maximum CPU time for the evaluation subprocess (POSIX only). Does not
+        bound sleeping/blocked processes; the wall-clock timeout covers those.
+
+    max_file_size_bytes : int, default=1 MiB
+        Maximum size of any file the evaluated code may write (POSIX only).
     """
     results = {"unit_test_passed": [], "stderr": []}
     utils_directory = os.path.dirname(os.path.abspath(__file__))
@@ -20,23 +65,27 @@ def evaluate_python_code(responses: List[str], public_test_cases: List[Any], met
             row["public_test_cases"] = json.loads(row["public_test_cases"])
         if isinstance(row.get("metadata"), str):
             row["metadata"] = json.loads(row["metadata"])
-        out = evaluate_row_unified(row, timeout=6, runner_path=os.path.join(utils_directory, "lcb_grader.py"))
+        out = evaluate_row_unified(row, timeout=timeout, runner_path=os.path.join(utils_directory, "lcb_grader.py"), memory_limit_bytes=memory_limit_bytes, cpu_time_limit_seconds=cpu_time_limit_seconds, max_file_size_bytes=max_file_size_bytes)
         results["unit_test_passed"].append(out.get("unit_test_passed", 0))
         results["stderr"].append(out.get("stderr", ""))
     return results
 
 
-def evaluate_row_unified(row, timeout=6, runner_path="lcb_grader.py"):
+def evaluate_row_unified(row, timeout=6, runner_path="lcb_grader.py", memory_limit_bytes=DEFAULT_MEMORY_LIMIT_BYTES, cpu_time_limit_seconds=DEFAULT_CPU_TIME_LIMIT_SECONDS, max_file_size_bytes=DEFAULT_MAX_FILE_SIZE_BYTES):
     """
     Evaluates a single row of the dataset using the LCB runner.
 
     - Sanitizes the model response to isolate valid code.
     - Parses public test cases and determines the testing mode (call-based or stdio).
-    - Builds the JSON payload expected by the LCB runner.
+    - Builds the JSON payload expected by the LCB runner, including resource limits.
     - Invokes the runner in a subprocess, passing the payload to standard input.
     - Captures stdout and stderr from the runner.
     - Decodes the final JSON report produced by the runner.
     - Returns the evaluation results.
+
+    The runner subprocess applies the memory/CPU/file-size limits via POSIX
+    rlimits before executing candidate code (not applied on Windows). This is
+    process-level isolation, not a security sandbox.
     """
     sanitized = sanitize_llm_output(row["response"])
 
@@ -48,7 +97,7 @@ def evaluate_row_unified(row, timeout=6, runner_path="lcb_grader.py"):
         func_name = row["metadata"].get("func_name")
 
     # Build payload for LCB runner
-    payload = {"code": sanitized, "public_test_cases": public_tests, "timeout": timeout}
+    payload = {"code": sanitized, "public_test_cases": public_tests, "timeout": timeout, "memory_limit_bytes": memory_limit_bytes, "cpu_time_limit_seconds": cpu_time_limit_seconds, "max_file_size_bytes": max_file_size_bytes}
 
     # Only include fn_name if it exists
     if func_name and isinstance(func_name, str) and len(func_name.strip()) > 0:

--- a/uqlm/code/lcb_grader.py
+++ b/uqlm/code/lcb_grader.py
@@ -36,6 +36,38 @@ from decimal import Decimal
 import time
 
 
+# Default resource limits applied to the evaluation process before candidate
+# code runs. Enforced via POSIX rlimits; on platforms without the `resource`
+# module (e.g. Windows) they are not applied, and macOS does not enforce
+# memory (address-space) rlimits. The hard wall-clock timeout in
+# code_evaluation.evaluate_row_unified applies on all platforms.
+DEFAULT_MEMORY_LIMIT_BYTES = 4 * 1024**3  # 4 GiB
+DEFAULT_CPU_TIME_LIMIT_SECONDS = 10
+DEFAULT_MAX_FILE_SIZE_BYTES = 1024**2  # 1 MiB
+DEFAULT_MAX_OPEN_FILES = 64
+
+
+def apply_resource_limits(cpu_time_limit_seconds: int = DEFAULT_CPU_TIME_LIMIT_SECONDS, max_file_size_bytes: int = DEFAULT_MAX_FILE_SIZE_BYTES, max_open_files: int = DEFAULT_MAX_OPEN_FILES) -> None:
+    """
+    Apply process-wide POSIX rlimits (CPU time, file size, open files) before
+    candidate code executes. Memory limits are applied separately via
+    reliability_guard(maximum_memory_bytes=...).
+
+    No-op on platforms without the `resource` module (e.g. Windows); each
+    limit is best-effort, so an rlimit the OS refuses to set does not abort
+    evaluation.
+    """
+    try:
+        import resource
+    except ImportError:
+        return
+    for rlimit, value in [(resource.RLIMIT_CPU, cpu_time_limit_seconds), (resource.RLIMIT_FSIZE, max_file_size_bytes), (resource.RLIMIT_NOFILE, max_open_files)]:
+        try:
+            resource.setrlimit(rlimit, (value, value))
+        except (ValueError, OSError):
+            pass
+
+
 # A large prelude of imports the evaluator prepends before executing candidate code.
 # This prevents "missing import" errors for common stdlib modules and sets recursionlimit.
 import_string = (
@@ -112,8 +144,15 @@ def main():
 
     sample, code, timeout = _build_sample_from_payload(data)
 
+    # Apply resource limits before any candidate code executes (POSIX only;
+    # no-op on Windows). Values are configurable via the payload.
+    memory_limit_bytes = int(data.get("memory_limit_bytes") or DEFAULT_MEMORY_LIMIT_BYTES)
+    cpu_time_limit_seconds = int(data.get("cpu_time_limit_seconds") or DEFAULT_CPU_TIME_LIMIT_SECONDS)
+    max_file_size_bytes = int(data.get("max_file_size_bytes") or DEFAULT_MAX_FILE_SIZE_BYTES)
+    apply_resource_limits(cpu_time_limit_seconds=cpu_time_limit_seconds, max_file_size_bytes=max_file_size_bytes)
+
     try:
-        results, meta = run_test(sample=sample, test=code, debug=False, timeout=timeout)
+        results, meta = run_test(sample=sample, test=code, debug=False, timeout=timeout, maximum_memory_bytes=memory_limit_bytes)
     except Exception as e:
         out = {"unit_test_passed": 0, "results": [], "meta": {"error_code": -4, "error_message": f"run_test exception: {e}"}, "stderr": f"run_test exception: {e}", "stdout": ""}
         print(json.dumps(out))
@@ -494,16 +533,19 @@ def grade_stdio(code: str, all_inputs: list, all_outputs: list, timeout: int):
     return all_results, {"execution time": total_execution_time}
 
 
-def run_test(sample, test=None, debug=False, timeout=6):
+def run_test(sample, test=None, debug=False, timeout=6, maximum_memory_bytes=DEFAULT_MEMORY_LIMIT_BYTES):
     """
     Orchestrator that decides whether to run call-based or stdio testing
     based on the presence of 'fn_name' inside sample["input_output"] JSON.
+
+    maximum_memory_bytes bounds the memory available to candidate code via
+    POSIX rlimits (not applied on platforms without the `resource` module).
     """
     # Set up SIGALRM timeout handler
     signal.signal(signal.SIGALRM, timeout_handler)
 
     # Disable destructive functions in this (sub)process
-    reliability_guard()
+    reliability_guard(maximum_memory_bytes=maximum_memory_bytes)
 
     if debug:
         print(f"start = {datetime.now().time()}", file=sys.stderr)
@@ -565,12 +607,19 @@ def reliability_guard(maximum_memory_bytes=None):
     """
 
     if maximum_memory_bytes is not None:
-        import resource
-
-        resource.setrlimit(resource.RLIMIT_AS, (maximum_memory_bytes, maximum_memory_bytes))
-        resource.setrlimit(resource.RLIMIT_DATA, (maximum_memory_bytes, maximum_memory_bytes))
-        if platform.uname().system != "Darwin":
-            resource.setrlimit(resource.RLIMIT_STACK, (maximum_memory_bytes, maximum_memory_bytes))
+        try:
+            import resource
+        except ImportError:
+            resource = None  # platform without POSIX rlimits (e.g. Windows)
+        if resource is not None:
+            limits = [resource.RLIMIT_AS, resource.RLIMIT_DATA]
+            if platform.uname().system != "Darwin":
+                limits.append(resource.RLIMIT_STACK)
+            for rlimit in limits:
+                try:
+                    resource.setrlimit(rlimit, (maximum_memory_bytes, maximum_memory_bytes))
+                except (ValueError, OSError):
+                    pass
 
     faulthandler.disable()
 

--- a/uqlm/scorers/shortform/codegen.py
+++ b/uqlm/scorers/shortform/codegen.py
@@ -83,6 +83,15 @@ class CodeGenUQ(ShortFormUQ):
 
         retries : int, default=5
             Specifies the number of retries to make if the equivalence score is not found.
+
+        Notes
+        -----
+        CodeGenUQ itself does not execute generated code. If you execute
+        model-generated code to benchmark it (e.g., with
+        ``uqlm.code.code_evaluation.evaluate_python_code``), note that the code
+        runs in a subprocess with resource limits and a wall-clock timeout;
+        this is process-level isolation, not a security sandbox. Run untrusted
+        code only in an isolated environment (container/VM).
         """
         super().__init__(llm=llm, max_calls_per_min=max_calls_per_min, system_prompt=system_prompt)
         self.scorers = scorers


### PR DESCRIPTION
## Description

`evaluate_python_code` runs model-generated code in a subprocess, but that subprocess could allocate unlimited memory, spin the CPU forever, or write files of any size — enough to take down the host mid-benchmark. Only a wall-clock timeout was enforced.

This PR bounds all three:

- **Three new parameters on `evaluate_python_code`**, applied as POSIX rlimits before the candidate code runs: `memory_limit_bytes` (default 4 GiB), `cpu_time_limit_seconds` (10 s), `max_file_size_bytes` (1 MiB). The wall-clock `timeout` is unchanged.
- **Says plainly that this is process isolation, not a security sandbox.** The docstrings, the code-generation docs page, and the codegen demo now tell users to run untrusted code only in a container or VM.
- **Tests for each limit** (marked `integration`), plus the CI step that runs integration-marked tests with retries — finishing the rerun scoping started in #428.

| Limit | Linux | macOS | Windows |
|---|:---:|:---:|:---:|
| Memory (4 GiB) | ✅ | ❌ | ❌ |
| CPU time (10 s) | ✅ | ✅ | ❌ |
| File size (1 MiB) | ✅ | ✅ | ❌ |
| Wall-clock timeout | ✅ | ✅ | ✅ |

macOS does not enforce memory rlimits and Windows has no rlimits at all, so the memory-limit test is Linux-only. The docstrings state the same, so users know what holds on their platform.

No behavior change for normal runs: the defaults are well above what test-case execution needs.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Dependency update

## AI Disclosure
<!-- Required. See CONTRIBUTING.md AI Policy. PRs without this section completed will be rejected. -->
- [ ] No AI tools were used to develop this PR
- [x] AI tools were used, as disclosed below

## Checklist
- [x] I have personally read and can explain every line of this diff, including any AI-generated or AI-suggested code
- [x] I take full personal responsibility for the correctness, security, and scientific validity of this change
- [x] I have run this code and the relevant tests locally myself and confirmed the change works as intended, not merely that it looks plausible or that a tool reported success
- [x] Tests added or updated for all changed behavior
- [x] Docstrings updated for any new or modified public API
- [x] Type annotations added for any new or modified functions
- [x] `ruff check` and `ruff format` pass locally