### PR TITLE
fix: white-box defaults, deprecated scorer name, and p_true crash guard

### DIFF
--- a/tests/test_logprobs_scorer.py
+++ b/tests/test_logprobs_scorer.py
@@ -15,6 +15,7 @@
 import pytest
 import numpy as np
 from uqlm.white_box.baseclass.logprobs_scorer import LogprobsScorer
+from uqlm.white_box.single_logprobs import SingleLogprobsScorer, SINGLE_LOGPROBS_SCORER_NAMES
 
 
 @pytest.fixture
@@ -98,6 +99,16 @@ def test_extract_top_logprobs(mock_single_response_logprobs, scorer):
     for top_logprobs in result:
         assert isinstance(top_logprobs, np.ndarray)
         assert top_logprobs.shape[0] > 0
+
+
+def test_single_logprobs_scorer_default_no_key_error(mock_logprobs_results):
+    """SingleLogprobsScorer default evaluate must not raise KeyError (normalized_probability removed)."""
+    assert "normalized_probability" not in SINGLE_LOGPROBS_SCORER_NAMES
+    scorer = SingleLogprobsScorer()
+    result = scorer.evaluate(mock_logprobs_results)
+    assert "min_probability" in result
+    assert "sequence_probability" in result
+    assert "normalized_probability" not in result
 
 
 def test_compute_single_generation_scores(mock_logprobs_results, scorer):

--- a/tests/test_p_true.py
+++ b/tests/test_p_true.py
@@ -104,6 +104,22 @@ def test_extract_ptrue_from_logprobs_result_missing_logprob():
     assert score != score  # NaN check
 
 
+def test_ptrue_scorer_init_no_logprobs_field():
+    """PTrueScorer must not raise when the llm has no logprobs field."""
+    from unittest.mock import MagicMock
+    llm = MagicMock(spec=[])  # no logprobs attribute
+    with pytest.MonkeyPatch().context() as mp:
+        mp.setattr("uqlm.white_box.p_true.ResponseGenerator.__init__", lambda self, *a, **kw: None)
+        scorer = PTrueScorer(llm=llm)
+    assert scorer is not None
+
+
+def test_extract_ptrue_empty_logprobs():
+    """Empty logprobs list must return NaN instead of raising IndexError."""
+    result = PTrueScorer._extract_ptrue_from_logprobs_result([])
+    assert result != result  # NaN check
+
+
 def test_construct_ptrue_prompt():
     """Test the _construct_ptrue_prompt method."""
     prompt = "What is 2+2?"

--- a/tests/test_whiteboxuq.py
+++ b/tests/test_whiteboxuq.py
@@ -102,6 +102,12 @@ async def test_whiteboxuq_p_true(monkeypatch):
     assert "p_true" in results.data
 
 
+def test_whiteboxuq_default_scorers():
+    """WhiteBoxUQ() with no args must use exactly the two documented defaults."""
+    wbuq = WhiteBoxUQ(llm=mock_object)
+    assert set(wbuq.scorers) == {"sequence_probability", "min_probability"}
+
+
 def test_whiteboxuq_invalid_scorer():
     with pytest.raises(ValueError, match="Invalid scorer provided: invalid_scorer"):
         WhiteBoxUQ(llm=mock_object, scorers=["invalid_scorer"])

--- a/uqlm/scorers/shortform/white_box.py
+++ b/uqlm/scorers/shortform/white_box.py
@@ -20,7 +20,7 @@ from uqlm.white_box.single_logprobs import SingleLogprobsScorer, SINGLE_LOGPROBS
 from uqlm.white_box.top_logprobs import TopLogprobsScorer, TOP_LOGPROBS_SCORER_NAMES
 from uqlm.white_box.sampled_logprobs import SampledLogprobsScorer, SAMPLED_LOGPROBS_SCORER_NAMES
 from uqlm.white_box.p_true import PTrueScorer
-from uqlm.scorers.shortform.baseclass.uncertainty import ShortFormUQ
+from uqlm.scorers.shortform.baseclass.uncertainty import ShortFormUQ, DEFAULT_WHITE_BOX_SCORERS
 from uqlm.utils.results import UQResult
 from uqlm.utils.warn import beta_warning
 
@@ -64,7 +64,7 @@ class WhiteBoxUQ(ShortFormUQ):
             defaults to "You are a helpful assistant."
 
         scorers : List[str], default=None
-            Specifies which white-box UQ scorers to include. Must be subset of ["sequence_probability", "min_probability", "max_token_negentropy", "mean_token_negentropy", "probability_margin", "monte_carlo_probability", "consistency_and_confidence", "semantic_negentropy", "semantic_density", "p_true"]. If None, defaults to ["sequence_probability", "min_probability"].
+            Specifies which white-box UQ scorers to include. Must be subset of ["sequence_probability", "min_probability", "min_token_negentropy", "mean_token_negentropy", "probability_margin", "monte_carlo_probability", "consistency_and_confidence", "semantic_negentropy", "semantic_density", "p_true"]. If None, defaults to ["sequence_probability", "min_probability"].
 
         sampling_temperature : float, default=1.0
             The 'temperature' parameter for llm model to generate sampled LLM responses. Must be greater than 0.
@@ -206,7 +206,7 @@ class WhiteBoxUQ(ShortFormUQ):
     def _validate_scorers(self, scorers: List[str], top_k_logprobs: int) -> None:
         """Validate and store scorer list"""
         if not scorers:
-            self.scorers = self.white_box_names
+            self.scorers = list(DEFAULT_WHITE_BOX_SCORERS)
         else:
             if "normalized_probability" in scorers:
                 raise ValueError("normalized_probability is deprecated as of v0.5 in favor of sequence_probability with length_normalize=True")

--- a/uqlm/white_box/p_true.py
+++ b/uqlm/white_box/p_true.py
@@ -34,7 +34,8 @@ Guidelines for your evaluation:
 
 class PTrueScorer:
     def __init__(self, llm: BaseChatModel, max_calls_per_min: Optional[int] = None) -> None:
-        llm.logprobs = True
+        if hasattr(llm, "logprobs"):
+            llm.logprobs = True
         self.response_generator = ResponseGenerator(llm, max_calls_per_min=max_calls_per_min)
         self.response_generator.response_generator_type = "p_true"
 
@@ -51,6 +52,8 @@ class PTrueScorer:
 
     @staticmethod
     def _extract_ptrue_from_logprobs_result(logprobs_result: List[Dict[str, Any]]) -> float:
+        if not logprobs_result:
+            return np.nan
         first_token_data = logprobs_result[0]
         token = first_token_data.get("token", "").strip().lower()
         logprob = first_token_data.get("logprob", None)

--- a/uqlm/white_box/single_logprobs.py
+++ b/uqlm/white_box/single_logprobs.py
@@ -18,7 +18,7 @@ from typing import List, Dict, Any
 from uqlm.white_box.baseclass.logprobs_scorer import LogprobsScorer
 
 
-SINGLE_LOGPROBS_SCORER_NAMES = ["normalized_probability", "min_probability", "sequence_probability"]
+SINGLE_LOGPROBS_SCORER_NAMES = ["min_probability", "sequence_probability"]
 
 
 class SingleLogprobsScorer(LogprobsScorer):


### PR DESCRIPTION
## Description
Three bugs in the white-box scorer package, all reachable from documented default usage. Address #438
**1. `WhiteBoxUQ()` ran all 10 scorers instead of the 2 in its docstring.**
The docstring promises `["sequence_probability", "min_probability"]`, but the code fell back to the full scorer list — silently pulling in `p_true` (an extra LLM call per prompt) and sampled scorers that trigger extra generation plus NLI and sentence-transformer downloads. The default now uses the `DEFAULT_WHITE_BOX_SCORERS` constant, which was already defined but never referenced. Also fixes a docstring typo: `max_token_negentropy` → `min_token_negentropy` (the real name — following the docs raised `ValueError`).
**2. `SingleLogprobsScorer()` crashed on its own default.**
`SINGLE_LOGPROBS_SCORER_NAMES` still listed the deprecated `normalized_probability`, which `evaluate()` never produces, so the default `evaluate()` raised `KeyError`. Removed from the list.
**3. `p_true` crashed on empty logprobs.**
`_extract_ptrue_from_logprobs_result` indexed `logprobs_result[0]` with no guard, so an empty or refused generation raised `IndexError` and killed the whole batch. It now returns `np.nan`, matching the sentinel used for the missing-logprob case directly below it.
**Tests:** one regression test per bug — the default scorer set, `SingleLogprobsScorer`'s default `evaluate()`, and empty logprobs returning NaN. Each fails without the corresponding fix.
**Behavior change:** code relying on the bare `WhiteBoxUQ()` default now gets 2 score columns instead of 10 — and stops paying for the extra LLM calls and model downloads. Pass `scorers=[...]` explicitly to keep the old set. `SINGLE_LOGPROBS_SCORER_NAMES` is also one entry shorter for anyone importing it directly.
## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation update
- [ ] Dependency update
## AI Disclosure
<!-- Required. See CONTRIBUTING.md AI Policy. PRs without this section completed will be rejected. -->
- [ ] No AI tools were used to develop this PR
- [x] AI tools were used, as disclosed below
REPLACE THIS LINE: name the tool(s), what each was used for (drafted the fix, wrote the tests, wrote docstrings), and which files/lines are AI generated or AI assisted.
## Checklist
- [x] I have personally read and can explain every line of this diff, including any AI-generated or AI-suggested code
- [x] I take full personal responsibility for the correctness, security, and scientific validity of this change
- [x] I have run this code and the relevant tests locally myself and confirmed the change works as intended, not merely that it looks plausible or that a tool reported success
- [x] Tests added or updated for all changed behavior
- [x] Docstrings updated for any new or modified public API
- [x] Type annotations added for any new or modified functions
- [x] `ruff check` and `ruff format` pass locally