### PR TITLE
fix: restore LLM state and progress bar lifecycle (M5, M7)

### DIFF
--- a/tests/test_uncertainty.py
+++ b/tests/test_uncertainty.py
@@ -214,6 +214,48 @@ def test_construct_black_box_return_data_variants():
     assert result["sampled_responses"] == uq.raw_sampled_responses
 
 
+@pytest.mark.asyncio
+async def test_generate_responses_restores_temperature_on_exception(monkeypatch):
+    """Regression test for M5: temperature must be restored even when generation raises."""
+    from langchain_openai import AzureChatOpenAI
+
+    llm = AzureChatOpenAI(deployment_name="D", temperature=0.3, api_key="k", api_version="2024-05-01-preview", azure_endpoint="https://mocked.endpoint.com")
+    uq = ShortFormUQ(llm=llm)
+
+    async def mock_generate(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("uqlm.utils.response_generator.ResponseGenerator.generate_responses", mock_generate)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await uq._generate_responses(prompts=["p"], count=5, temperature=2.0)
+    assert llm.temperature == 0.3
+
+
+def test_preserve_llm_logprobs_restores_on_exception():
+    """Regression test for M5: _preserve_llm_logprobs restores logprobs even on exception."""
+    uq = ShortFormUQ(llm=mock_object)
+    uq.llm.logprobs = False
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with uq._preserve_llm_logprobs():
+            uq.llm.logprobs = True
+            raise RuntimeError("boom")
+    assert uq.llm.logprobs is False
+
+
+def test_preserve_llm_logprobs_no_op_without_attribute():
+    """CM is a no-op when the LLM lacks a logprobs attribute (e.g. ChatAnthropic)."""
+
+    class NoLogprobsLLM:
+        temperature = 0.0
+
+    uq = ShortFormUQ(llm=NoLogprobsLLM())
+    with uq._preserve_llm_logprobs() as has_logprobs:
+        assert has_logprobs is False
+    # No AttributeError raised
+
+
 def test_progress_bar_exceptions(monkeypatch):
     uq = ShortFormUQ(llm=mock_object)
 

--- a/tests/test_whiteboxuq.py
+++ b/tests/test_whiteboxuq.py
@@ -108,6 +108,48 @@ def test_whiteboxuq_invalid_scorer():
 
 
 @pytest.mark.asyncio
+async def test_whiteboxuq_generate_and_score_exception_restores_llm(monkeypatch):
+    """Regression test for M5: mid-generation exception must restore temperature and logprobs."""
+    llm = AzureChatOpenAI(deployment_name="D", temperature=0.3, api_key="k", api_version="2024-05-01-preview", azure_endpoint="https://mocked.endpoint.com")
+    llm.logprobs = False
+    original_temp = llm.temperature
+    original_logprobs = llm.logprobs
+
+    wbuq = WhiteBoxUQ(llm=llm, scorers=["monte_carlo_probability"], sampling_temperature=2.0)
+
+    call_state = {"n": 0}
+
+    async def flaky_generate(*args, **kwargs):
+        call_state["n"] += 1
+        if call_state["n"] == 1:
+            responses = ["r"] * len(PROMPTS)
+            return {"data": {"response": responses}, "metadata": {"logprobs": MOCKED_LOGPROBS}}
+        raise RuntimeError("boom during candidate gen")
+
+    monkeypatch.setattr("uqlm.utils.response_generator.ResponseGenerator.generate_responses", flaky_generate)
+
+    with pytest.raises(RuntimeError, match="boom during candidate gen"):
+        await wbuq.generate_and_score(prompts=PROMPTS, show_progress_bars=False)
+
+    assert llm.temperature == original_temp
+    assert llm.logprobs == original_logprobs
+
+
+@pytest.mark.asyncio
+async def test_whiteboxuq_score_twice_no_liveerror():
+    """Regression test for M7: WhiteBoxUQ.score() must not leave a live progress bar."""
+    wbuq_a = WhiteBoxUQ(llm=mock_object, scorers=["sequence_probability", "min_probability"])
+    r1 = await wbuq_a.score(logprobs_results=MOCKED_LOGPROBS, show_progress_bars=True)
+    r2 = await wbuq_a.score(logprobs_results=MOCKED_LOGPROBS, show_progress_bars=True)
+
+    wbuq_b = WhiteBoxUQ(llm=mock_object, scorers=["sequence_probability"])
+    r3 = await wbuq_b.score(logprobs_results=MOCKED_LOGPROBS, show_progress_bars=True)
+
+    for r in (r1, r2, r3):
+        assert "sequence_probability" in r.data
+
+
+@pytest.mark.asyncio
 async def test_whiteboxuq_top_logprobs_full(monkeypatch):
     wbuq = WhiteBoxUQ(llm=mock_object, scorers=["mean_token_negentropy"], top_k_logprobs=10)
 

--- a/uqlm/scorers/baseclass/uncertainty.py
+++ b/uqlm/scorers/baseclass/uncertainty.py
@@ -131,7 +131,6 @@ class UncertaintyQuantifier:
         list of list of str
             A list of sampled responses for each prompt.
         """
-        llm_temperature = self.llm.temperature
         generations = await self._generate_responses(prompts=prompts, count=num_responses, temperature=self.sampling_temperature, top_k_logprobs=None, progress_bar=progress_bar)
         tmp_mr, tmp_lp = generations["responses"], generations["logprobs"]
         sampled_responses, self.multiple_logprobs = [], []
@@ -142,26 +141,47 @@ class UncertaintyQuantifier:
         if self.postprocessor:
             self.raw_sampled_responses = sampled_responses
             sampled_responses = [[self.postprocessor(r) for r in m] for m in sampled_responses]
-        self.llm.temperature = llm_temperature
         return sampled_responses
 
     async def _generate_responses(self, prompts: List[Union[str, List[BaseMessage]]], count: int, temperature: float = None, top_k_logprobs: Optional[int] = None, progress_bar: Optional[Progress] = None) -> List[str]:
         """Helper function to generate responses with LLM"""
+        if self.llm is None:
+            raise ValueError("""llm must be provided to generate responses.""")
+        llm_temperature = self.llm.temperature
+        if temperature:
+            self.llm.temperature = temperature
         try:
-            if self.llm is None:
-                raise ValueError("""llm must be provided to generate responses.""")
-            llm_temperature = self.llm.temperature
-            if temperature:
-                self.llm.temperature = temperature
             generator_object = ResponseGenerator(llm=self.llm, max_calls_per_min=self.max_calls_per_min, use_n_param=self.use_n_param, top_k_logprobs=top_k_logprobs, structured_response=self.structured_response, output_extractor=self.output_extractor)
             with contextlib.redirect_stdout(io.StringIO()):
                 generations = await generator_object.generate_responses(prompts=prompts, count=count, system_prompt=self.system_prompt, progress_bar=progress_bar)
-            self.llm.temperature = llm_temperature
         except Exception:
             if progress_bar:
                 progress_bar.stop()
             raise
+        finally:
+            self.llm.temperature = llm_temperature
         return {"responses": generations["data"]["response"], "logprobs": generations["metadata"]["logprobs"]}
+
+    @contextlib.contextmanager
+    def _preserve_llm_logprobs(self):
+        """Snapshot ``self.llm.logprobs`` and restore it on exit.
+
+        No-op when the LLM is None or lacks a ``logprobs`` attribute (e.g. ``ChatAnthropic``).
+        Callers may safely set ``self.llm.logprobs = True`` inside the block; the original
+        value is restored even if an exception propagates out.
+        """
+        has_logprobs = self.llm is not None and hasattr(self.llm, "logprobs")
+        if not has_logprobs:
+            yield False
+            return
+        original_logprobs = self.llm.logprobs
+        try:
+            yield True
+        finally:
+            try:
+                self.llm.logprobs = original_logprobs
+            except Exception:
+                pass
 
     def _validate_structured_output_parameters(self) -> None:
         if self.structured_response and not self.output_extractor:

--- a/uqlm/scorers/longform/baseclass/uncertainty.py
+++ b/uqlm/scorers/longform/baseclass/uncertainty.py
@@ -182,14 +182,22 @@ class LongFormUQ(UncertaintyQuantifier):
 
     def _display_decomposition_header(self, show_progress_bars: bool) -> None:
         """Displays decomposition header"""
-        if show_progress_bars:
-            self.progress_bar.start()
-            self.progress_bar.add_task("")
-            self.progress_bar.add_task("✂️ Decomposition")
+        if show_progress_bars and self.progress_bar:
+            try:
+                self.progress_bar.start()
+                self.progress_bar.add_task("")
+                self.progress_bar.add_task("✂️ Decomposition")
+            except (AttributeError, RuntimeError, OSError):
+                # If progress bar fails, just continue without it
+                pass
 
     def _display_reconstruction_header(self, show_progress_bars: bool) -> None:
         """Displays decomposition header"""
-        if show_progress_bars:
-            self.progress_bar.start()
-            self.progress_bar.add_task("")
-            self.progress_bar.add_task("✅️ Refinement")
+        if show_progress_bars and self.progress_bar:
+            try:
+                self.progress_bar.start()
+                self.progress_bar.add_task("")
+                self.progress_bar.add_task("✅️ Refinement")
+            except (AttributeError, RuntimeError, OSError):
+                # If progress bar fails, just continue without it
+                pass

--- a/uqlm/scorers/shortform/codegen.py
+++ b/uqlm/scorers/shortform/codegen.py
@@ -98,15 +98,15 @@ class CodeGenUQ(ShortFormUQ):
         self._validate_scorers()
 
     async def generate_and_score(self, prompts: List[str], num_responses: Optional[int] = 5, show_progress_bars: Optional[bool] = True) -> UQResult:
-        # self._construct_progress_bar(True)
-        self._construct_progress_bar(show_progress_bars)
-        self._display_generation_header(show_progress_bars, generation_type=self.generation_type)
-        if self.wbuq_scorers:
-            self.llm.logprobs = True
-        self.responses = await self.generate_original_responses(prompts, top_k_logprobs=self.top_k_logprobs, progress_bar=self.progress_bar)
-        self.sampled_responses = await self.generate_candidate_responses(prompts=prompts, num_responses=num_responses, progress_bar=self.progress_bar)
-        results = await self.score(prompts=prompts, responses=self.responses, sampled_responses=self.sampled_responses, logprobs_results=self.logprobs, sampled_logprobs_results=self.multiple_logprobs, show_progress_bars=show_progress_bars)
-        return results
+        with self._preserve_llm_logprobs():
+            self._construct_progress_bar(show_progress_bars)
+            self._display_generation_header(show_progress_bars, generation_type=self.generation_type)
+            if self.wbuq_scorers:
+                self.llm.logprobs = True
+            self.responses = await self.generate_original_responses(prompts, top_k_logprobs=self.top_k_logprobs, progress_bar=self.progress_bar)
+            self.sampled_responses = await self.generate_candidate_responses(prompts=prompts, num_responses=num_responses, progress_bar=self.progress_bar)
+            results = await self.score(prompts=prompts, responses=self.responses, sampled_responses=self.sampled_responses, logprobs_results=self.logprobs, sampled_logprobs_results=self.multiple_logprobs, show_progress_bars=show_progress_bars)
+            return results
 
     async def score(self, prompts: List[str], responses: List[str], sampled_responses: List[List[str]], logprobs_results: List[List[float]], sampled_logprobs_results: List[List[float]], show_progress_bars: Optional[bool] = True, _display_header: bool = True) -> UQResult:
         data = {"prompts": prompts, "responses": responses, "sampled_responses": sampled_responses}
@@ -135,7 +135,7 @@ class CodeGenUQ(ShortFormUQ):
         # Compute White-box UQ scores
         if len(self.wbuq_scorers) > 0:
             self.wbuq.progress_bar = self.progress_bar
-            self.wb_results = await self.wbuq.score(prompts=prompts, responses=responses, sampled_responses=sampled_responses, logprobs_results=logprobs_results, sampled_logprobs_results=sampled_logprobs_results, _display_header=False)
+            self.wb_results = await self.wbuq.score(prompts=prompts, responses=responses, sampled_responses=sampled_responses, logprobs_results=logprobs_results, sampled_logprobs_results=sampled_logprobs_results, _display_header=False, _existing_progress_bar=self.progress_bar)
             for key in self.wb_results.data:
                 if key in self.scorers:
                     data[key] = self.wb_results.data[key]

--- a/uqlm/scorers/shortform/density.py
+++ b/uqlm/scorers/shortform/density.py
@@ -133,17 +133,18 @@ class SemanticDensity(ShortFormUQ):
         self.num_responses = num_responses
         self.nli.num_responses = num_responses
 
-        if hasattr(self.llm, "logprobs"):
-            self.llm.logprobs = True
-        else:
+        if not hasattr(self.llm, "logprobs"):
             raise ValueError("The provided LLM does not support logprobs access. Cannot compute semantic density.")
 
-        self._construct_progress_bar(show_progress_bars)
-        self._display_generation_header(show_progress_bars)
+        with self._preserve_llm_logprobs():
+            self.llm.logprobs = True
 
-        responses = await self.generate_original_responses(prompts, progress_bar=self.progress_bar)
-        sampled_responses = await self.generate_candidate_responses(prompts, num_responses=self.num_responses, progress_bar=self.progress_bar)
-        return self.score(prompts=self.prompts, responses=responses, sampled_responses=sampled_responses, show_progress_bars=show_progress_bars)
+            self._construct_progress_bar(show_progress_bars)
+            self._display_generation_header(show_progress_bars)
+
+            responses = await self.generate_original_responses(prompts, progress_bar=self.progress_bar)
+            sampled_responses = await self.generate_candidate_responses(prompts, num_responses=self.num_responses, progress_bar=self.progress_bar)
+            return self.score(prompts=self.prompts, responses=responses, sampled_responses=sampled_responses, show_progress_bars=show_progress_bars)
 
     def score(self, prompts: List[str] = None, responses: List[str] = None, sampled_responses: List[List[str]] = None, logprobs_results: List[List[Dict[str, Any]]] = None, sampled_logprobs_results: List[List[List[Dict[str, Any]]]] = None, show_progress_bars: Optional[bool] = True, _display_header: bool = True) -> UQResult:
         """

--- a/uqlm/scorers/shortform/ensemble.py
+++ b/uqlm/scorers/shortform/ensemble.py
@@ -174,34 +174,38 @@ class UQEnsemble(ShortFormUQ):
             assert hasattr(self.llm, "logprobs"), """
             In order to use white-box components, BaseChatModel must have logprobs attribute
             """
-            self.llm.logprobs = True
 
         if self.judges:
             if not all(isinstance(item, str) for item in prompts):
                 raise ValueError("prompts must be list of strings when using LLM judges with UQEnsemble")
-        self._construct_progress_bar(show_progress_bars, _existing_progress_bar=_existing_progress_bar)
-        self._display_generation_header(show_progress_bars)
 
-        # Determine if we need top_k_logprobs for top-logprobs scorers
-        top_k_logprobs = None
-        if self.white_box_components:
-            if any(scorer in TOP_LOGPROBS_SCORER_NAMES for scorer in self.white_box_components):
-                top_k_logprobs = 15
+        with self._preserve_llm_logprobs():
+            if self.white_box_components:
+                self.llm.logprobs = True
 
-        responses = await self.generate_original_responses(prompts, top_k_logprobs=top_k_logprobs, progress_bar=self.progress_bar)
+            self._construct_progress_bar(show_progress_bars, _existing_progress_bar=_existing_progress_bar)
+            self._display_generation_header(show_progress_bars)
 
-        # Generate sampled responses if needed by black-box or sampled-logprobs white-box scorers
-        needs_sampled_responses = self.black_box_components or (self.white_box_components and any(scorer in SAMPLED_LOGPROBS_SCORER_NAMES for scorer in self.white_box_components))
-        if needs_sampled_responses:
-            sampled_responses = await self.generate_candidate_responses(prompts, num_responses=self.num_responses, progress_bar=self.progress_bar)
-        else:
-            sampled_responses = None
-            self.multiple_logprobs = [[None] * self.num_responses for _ in prompts]
+            # Determine if we need top_k_logprobs for top-logprobs scorers
+            top_k_logprobs = None
+            if self.white_box_components:
+                if any(scorer in TOP_LOGPROBS_SCORER_NAMES for scorer in self.white_box_components):
+                    top_k_logprobs = 15
 
-        result = await self.score(prompts=prompts, responses=responses, sampled_responses=sampled_responses, logprobs_results=self.logprobs, sampled_logprobs_results=self.multiple_logprobs, show_progress_bars=show_progress_bars, _existing_progress_bar=_existing_progress_bar)
+            responses = await self.generate_original_responses(prompts, top_k_logprobs=top_k_logprobs, progress_bar=self.progress_bar)
 
-        self._stop_progress_bar(_existing_progress_bar)  # if re-run ensure the same progress object is not used
-        return result
+            # Generate sampled responses if needed by black-box or sampled-logprobs white-box scorers
+            needs_sampled_responses = self.black_box_components or (self.white_box_components and any(scorer in SAMPLED_LOGPROBS_SCORER_NAMES for scorer in self.white_box_components))
+            if needs_sampled_responses:
+                sampled_responses = await self.generate_candidate_responses(prompts, num_responses=self.num_responses, progress_bar=self.progress_bar)
+            else:
+                sampled_responses = None
+                self.multiple_logprobs = [[None] * self.num_responses for _ in prompts]
+
+            result = await self.score(prompts=prompts, responses=responses, sampled_responses=sampled_responses, logprobs_results=self.logprobs, sampled_logprobs_results=self.multiple_logprobs, show_progress_bars=show_progress_bars, _existing_progress_bar=_existing_progress_bar)
+
+            self._stop_progress_bar(_existing_progress_bar)  # if re-run ensure the same progress object is not used
+            return result
 
     async def score(
         self, prompts: List[str], responses: List[str], sampled_responses: Optional[List[List[str]]] = None, logprobs_results: Optional[List[List[Dict[str, Any]]]] = None, sampled_logprobs_results: Optional[List[List[List[Dict[str, Any]]]]] = None, num_responses: int = 5, show_progress_bars: Optional[bool] = True, _existing_progress_bar: Optional[rich.progress.Progress] = None

--- a/uqlm/scorers/shortform/entropy.py
+++ b/uqlm/scorers/shortform/entropy.py
@@ -154,18 +154,19 @@ class SemanticEntropy(ShortFormUQ):
         self.num_responses = num_responses
         self.nli.num_responses = num_responses
 
-        if hasattr(self.llm, "logprobs"):
-            self.llm.logprobs = True
-            self.use_logprobs = True
-        else:
-            warnings.warn("The provided LLM does not support logprobs access. Only discrete semantic entropy will be computed.")
+        with self._preserve_llm_logprobs() as has_logprobs:
+            if has_logprobs:
+                self.llm.logprobs = True
+                self.use_logprobs = True
+            else:
+                warnings.warn("The provided LLM does not support logprobs access. Only discrete semantic entropy will be computed.")
 
-        self._construct_progress_bar(show_progress_bars)
-        self._display_generation_header(show_progress_bars)
+            self._construct_progress_bar(show_progress_bars)
+            self._display_generation_header(show_progress_bars)
 
-        responses = await self.generate_original_responses(prompts, progress_bar=self.progress_bar)
-        sampled_responses = await self.generate_candidate_responses(prompts, num_responses=self.num_responses, progress_bar=self.progress_bar)
-        return self.score(prompts=prompts, responses=responses, sampled_responses=sampled_responses, show_progress_bars=show_progress_bars)
+            responses = await self.generate_original_responses(prompts, progress_bar=self.progress_bar)
+            sampled_responses = await self.generate_candidate_responses(prompts, num_responses=self.num_responses, progress_bar=self.progress_bar)
+            return self.score(prompts=prompts, responses=responses, sampled_responses=sampled_responses, show_progress_bars=show_progress_bars)
 
     def score(self, prompts: List[str] = None, responses: List[str] = None, sampled_responses: List[List[str]] = None, logprobs_results: Optional[List[List[Dict[str, Any]]]] = None, sampled_logprobs_results: Optional[List[List[List[Dict[str, Any]]]]] = None, show_progress_bars: Optional[bool] = True, _display_header: bool = True) -> UQResult:
         """

--- a/uqlm/scorers/shortform/white_box.py
+++ b/uqlm/scorers/shortform/white_box.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from typing import Any, Dict, List, Optional, Union
+import rich
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import BaseMessage
 
@@ -134,23 +135,34 @@ class WhiteBoxUQ(ShortFormUQ):
         assert hasattr(self.llm, "logprobs"), """
         BaseChatModel must have logprobs attribute and have logprobs=True
         """
-        self.llm.logprobs = True
-        sampled_responses = None
+        with self._preserve_llm_logprobs():
+            self.llm.logprobs = True
+            sampled_responses = None
 
-        self._construct_progress_bar(show_progress_bars)
-        self._display_generation_header(show_progress_bars, generation_type="white_box")
+            self._construct_progress_bar(show_progress_bars)
+            self._display_generation_header(show_progress_bars, generation_type="white_box")
 
-        responses = await self.generate_original_responses(prompts, top_k_logprobs=self.top_k_logprobs, progress_bar=self.progress_bar)
-        if self.sampled_logprobs_scorer_names:
-            self.llm.logprobs = True  # reset attribute to True
-            sampled_responses = await self.generate_candidate_responses(prompts=prompts, num_responses=num_responses, progress_bar=self.progress_bar)
-        result = await self.score(prompts=prompts, responses=responses, sampled_responses=sampled_responses, logprobs_results=self.logprobs, sampled_logprobs_results=self.multiple_logprobs, show_progress_bars=show_progress_bars)
+            responses = await self.generate_original_responses(prompts, top_k_logprobs=self.top_k_logprobs, progress_bar=self.progress_bar)
+            if self.sampled_logprobs_scorer_names:
+                self.llm.logprobs = True  # response_generator may set this to top_k_logprobs; reset for candidate generation
+                sampled_responses = await self.generate_candidate_responses(prompts=prompts, num_responses=num_responses, progress_bar=self.progress_bar)
+            result = await self.score(prompts=prompts, responses=responses, sampled_responses=sampled_responses, logprobs_results=self.logprobs, sampled_logprobs_results=self.multiple_logprobs, show_progress_bars=show_progress_bars, _existing_progress_bar=self.progress_bar)
 
-        self._stop_progress_bar()
-        self.progress_bar = None  # if re-run ensure the same progress object is not used
-        return result
+            self._stop_progress_bar()
+            self.progress_bar = None  # if re-run ensure the same progress object is not used
+            return result
 
-    async def score(self, logprobs_results: List[List[Dict[str, Any]]], prompts: Optional[List[str]] = None, responses: Optional[List[str]] = None, sampled_responses: Optional[List[List[str]]] = None, sampled_logprobs_results: Optional[List[List[List[Dict[str, Any]]]]] = None, show_progress_bars: Optional[bool] = True, _display_header: bool = True) -> UQResult:
+    async def score(
+        self,
+        logprobs_results: List[List[Dict[str, Any]]],
+        prompts: Optional[List[str]] = None,
+        responses: Optional[List[str]] = None,
+        sampled_responses: Optional[List[List[str]]] = None,
+        sampled_logprobs_results: Optional[List[List[List[Dict[str, Any]]]]] = None,
+        show_progress_bars: Optional[bool] = True,
+        _display_header: bool = True,
+        _existing_progress_bar: Optional[rich.progress.Progress] = None,
+    ) -> UQResult:
         """
         Compute white-box confidence scores from provided logprobs.
 
@@ -180,7 +192,7 @@ class WhiteBoxUQ(ShortFormUQ):
         UQResult
             UQResult containing prompts, responses, logprobs, and white-box UQ scores
         """
-        self._construct_progress_bar(show_progress_bars)
+        self._construct_progress_bar(show_progress_bars, _existing_progress_bar=_existing_progress_bar)
         self._display_scoring_header(show_progress_bars and _display_header and self.scorers_with_scoring_header)
 
         data = {"prompts": prompts, "responses": responses, "logprob": logprobs_results, "sampled_responses": sampled_responses, "sampled_logprob": sampled_logprobs_results}
@@ -201,6 +213,9 @@ class WhiteBoxUQ(ShortFormUQ):
             p_true_scores_dict = await self.p_true_scorer.evaluate(prompts=prompts, responses=responses, sampled_responses=sampled_responses, progress_bar=self.progress_bar)
             data.update(p_true_scores_dict)
         result = {"data": data, "metadata": {"temperature": None if not self.llm else self.llm.temperature}}
+        if _existing_progress_bar is None:
+            self._stop_progress_bar()
+            self.progress_bar = None  # if re-run ensure the same progress object is not used
         return UQResult(result)
 
     def _validate_scorers(self, scorers: List[str], top_k_logprobs: int) -> None:

--- a/uqlm/utils/grader.py
+++ b/uqlm/utils/grader.py
@@ -56,7 +56,6 @@ class LLMGrader:
             limit is specified.
 
         """
-        llm.logprobs = True
         self.response_generator = ResponseGenerator(llm, max_calls_per_min=max_calls_per_min)
         self.response_generator.response_generator_type = "grader"
 

--- a/uv.lock
+++ b/uv.lock
@@ -5517,7 +5517,7 @@ wheels = [
 
 [[package]]
 name = "sphinx"
-version = "7.4.7"
+version = "8.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "alabaster" },
@@ -5538,9 +5538,9 @@ dependencies = [
     { name = "sphinxcontrib-serializinghtml" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/be/50e50cb4f2eff47df05673d361095cafd95521d2a22521b920c67a372dcb/sphinx-7.4.7.tar.gz", hash = "sha256:242f92a7ea7e6c5b406fdc2615413890ba9f699114a9c09192d7dfead2ee9cfe", size = 8067911, upload-time = "2024-07-20T14:46:56.059Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927", size = 8184611, upload-time = "2024-10-13T20:27:13.93Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/ef/153f6803c5d5f8917dbb7f7fcf6d34a871ede3296fa89c2c703f5f8a6c8e/sphinx-7.4.7-py3-none-any.whl", hash = "sha256:c2419e2135d11f1951cd994d6eb18a1835bd8fdd8429f9ca375dc1f3281bd239", size = 3401624, upload-time = "2024-07-20T14:46:52.142Z" },
+    { url = "https://files.pythonhosted.org/packages/26/60/1ddff83a56d33aaf6f10ec8ce84b4c007d9368b21008876fceda7e7381ef/sphinx-8.1.3-py3-none-any.whl", hash = "sha256:09719015511837b76bf6e03e42eb7595ac8c2e41eeb9c29c5b755c6b677992a2", size = 3487125, upload-time = "2024-10-13T20:27:10.448Z" },
 ]
 
 [[package]]
@@ -5569,14 +5569,16 @@ wheels = [
 
 [[package]]
 name = "sphinx-favicon"
-version = "1.0.1"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "imagesize" },
+    { name = "requests" },
     { name = "sphinx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/25/3c78b785c3ea991597c310ac6bdc7949c2a7549e031dbb22db4ce8d1b99b/sphinx-favicon-1.0.1.tar.gz", hash = "sha256:df796de32125609c1b4a8964db74270ebf4502089c27cd53f542354dc0b57e8e", size = 8162, upload-time = "2023-03-02T23:28:47.635Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/26/e7ca2321e6286d6ed6a2e824a0ee35ae660ec9a45a4719e33a627ce9e4d2/sphinx_favicon-1.1.0.tar.gz", hash = "sha256:6f65939fc2a6ac4259c88b09169f0b72681cd4c03dd1d0cf91c57a1fa314e50b", size = 8744, upload-time = "2026-02-12T20:55:41.294Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/c2/152bd6c211b847e525d2c7004fd98e3ac5baeace192716da8cd9c9ec2427/sphinx_favicon-1.0.1-py3-none-any.whl", hash = "sha256:7c93d6b634cb4c9687ceab67a8526f05d3b02679df94e273e51a43282e6b034c", size = 6997, upload-time = "2023-03-02T23:28:45.985Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/99/c85bc52d785557abddc4d8fdacfbcbda56fb3e715f76b9675fb9c2018aa5/sphinx_favicon-1.1.0-py3-none-any.whl", hash = "sha256:3ca71506fbb4d9a30bddc60a29e3fb8854f3e237ad95abad5a5c15f857d987b2", size = 7241, upload-time = "2026-02-12T20:55:40.312Z" },
 ]
 
 [[package]]
@@ -5594,16 +5596,16 @@ wheels = [
 
 [[package]]
 name = "sphinx-github-changelog"
-version = "1.4.0"
+version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docutils" },
     { name = "requests" },
     { name = "sphinx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8f/21/90bc47a6cdfff2e37bc233754f6662808975528a73dab0bf6a5215eeb2a5/sphinx_github_changelog-1.4.0.tar.gz", hash = "sha256:204745e93a1f280e4664977b5fee526b0a011c92ca19c304bd01fd641ddb6393", size = 7583, upload-time = "2024-08-09T16:08:36.116Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/8a/e3b943c59927280c9c5bfb94064845a57f36bc2e021435adbfb7d3ecca1f/sphinx_github_changelog-1.7.2.tar.gz", hash = "sha256:79f11f30ec5b1ae52a1742a6dc702644203b164732a1af4b049ebe522ff484e4", size = 78662, upload-time = "2026-03-23T21:49:45.238Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/07/a669a23f47803ad12e620b68b761bf7bf32fd9f293c5846fda8f3893d706/sphinx_github_changelog-1.4.0-py3-none-any.whl", hash = "sha256:cdf2099ea3e4587ae8637be7ba609738bfdeca4bd80c5df6fc45046735ae5c2f", size = 8513, upload-time = "2024-08-09T16:08:34.374Z" },
+    { url = "https://files.pythonhosted.org/packages/81/6c/d8db14cbf2171cae049660eacddf858a35818343e618b442993a8b0a8885/sphinx_github_changelog-1.7.2-py3-none-any.whl", hash = "sha256:fef384fb9b60bfb8f1c4cc5941dab674b0e52456cd3fe05ef2c763833054d680", size = 11416, upload-time = "2026-03-23T21:49:43.74Z" },
 ]
 
 [[package]]
@@ -5617,18 +5619,17 @@ wheels = [
 
 [[package]]
 name = "sphinxcontrib-bibtex"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docutils" },
     { name = "pybtex" },
     { name = "pybtex-docutils" },
-    { name = "setuptools", marker = "python_full_version >= '3.12'" },
     { name = "sphinx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/ce/054a8ec04063f9a27772fea7188f796edbfa382e656d3b76428323861f0e/sphinxcontrib_bibtex-2.6.3.tar.gz", hash = "sha256:7c790347ef1cb0edf30de55fc324d9782d085e89c52c2b8faafa082e08e23946", size = 117177, upload-time = "2024-09-12T14:23:44.662Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/6a/8e0b2c2420286389e7fed78ff361ec30e2f1d58c8560af8d64df5e7b61e0/sphinxcontrib_bibtex-2.7.0.tar.gz", hash = "sha256:fee700f7aae29bb8f654c62913f00d34ac44fc0b8ca0fa67ac922ff4453addee", size = 120669, upload-time = "2026-05-06T09:29:24.935Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/49/c23f9493c0a5d5881fb7ed3002e87708454fef860aa96a48e755d27bf6f0/sphinxcontrib_bibtex-2.6.3-py3-none-any.whl", hash = "sha256:ff016b738fcc867df0f75c29e139b3b2158d26a2c802db27963cb128be3b75fb", size = 40340, upload-time = "2024-09-12T14:23:43.593Z" },
+    { url = "https://files.pythonhosted.org/packages/52/c0/d28e62407f4733bbe0169287bc012f0ac3b4a2021066b285570654119c8b/sphinxcontrib_bibtex-2.7.0-py3-none-any.whl", hash = "sha256:28cf0ec7a957d1c7548d5749317ed472ce877e1b629f430f88e3789aa51f87b1", size = 40287, upload-time = "2026-05-06T09:29:23.253Z" },
 ]
 
 [[package]]
@@ -6168,7 +6169,7 @@ requires-dist = [
     { name = "scipy", marker = "python_full_version >= '3.13'", specifier = ">=1.15.0,<2.0.0" },
     { name = "sentence-transformers", specifier = ">=3.4,<6.0" },
     { name = "torch", specifier = ">=2.6.0" },
-    { name = "transformers", specifier = ">=4.45.2,<5.0.0" },
+    { name = "transformers", specifier = ">=4.45.2,<6.0.0" },
 ]
 provides-extras = ["accelerate"]
 
@@ -6184,20 +6185,20 @@ dev = [
 docs = [
     { name = "nbsphinx", specifier = "==0.9.8" },
     { name = "pydata-sphinx-theme", specifier = "==0.16.1" },
-    { name = "sphinx", specifier = "==7.4.7" },
+    { name = "sphinx", specifier = "==8.1.3" },
     { name = "sphinx-autodoc-typehints", specifier = "==2.3.0" },
     { name = "sphinx-design", specifier = "==0.6.1" },
-    { name = "sphinx-favicon", specifier = "==1.0.1" },
+    { name = "sphinx-favicon", specifier = "==1.1.0" },
     { name = "sphinx-gallery", specifier = "==0.20.0" },
-    { name = "sphinx-github-changelog", specifier = "==1.4.0" },
-    { name = "sphinxcontrib-bibtex", specifier = "==2.6.3" },
+    { name = "sphinx-github-changelog", specifier = "==1.7.2" },
+    { name = "sphinxcontrib-bibtex", specifier = "==2.7.0" },
 ]
 test = [
     { name = "ipykernel", specifier = ">=6.29.5,<7.0.0" },
     { name = "langchain-google-vertexai", specifier = ">=2.0.8" },
     { name = "langchain-openai", specifier = ">=0.2.6" },
-    { name = "pytest", specifier = ">=8.3.5,<9.0.0" },
-    { name = "pytest-asyncio", specifier = ">=0.25.3,<1.4.0" },
+    { name = "pytest", specifier = ">=8.3.5,<10.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.25.3,<1.5.0" },
     { name = "pytest-cov", specifier = ">=6,<8" },
     { name = "pytest-rerunfailures", specifier = ">=16.0,<17.0" },
 ]


### PR DESCRIPTION
Addresses #441 

  - Add `_preserve_llm_logprobs` context manager and use it at every `self.llm.logprobs = True` site (white_box, entropy, density, ensemble, codegen) so the caller's LLM is left untouched after a scorer run, including on exception. No-op when the LLM lacks the attribute (e.g. ChatAnthropic).
  - Move `self.llm.temperature` restore into `finally` in `_generate_responses` so a mid-generation exception no longer strands the user's LLM at the sampling temperature.
  - Drop the pointless `llm.logprobs = True` mutation in `utils/grader.py` (grader doesn't use logprobs).
  - Add `_stop_progress_bar` epilogue and `_existing_progress_bar` param to `WhiteBoxUQ.score` so calling it directly no longer leaves a live `rich.Live` running (which raised `LiveError` on the next scorer). Pass `_existing_progress_bar=self.progress_bar` from `codegen.score`.
  - Nil-guard `_display_decomposition_header` / `_display_reconstruction_header` to match the try/except pattern used by the other display helpers.

  Regression tests: temperature/logprobs restored after a mocked mid-generation
  exception; `WhiteBoxUQ.score()` twice + another scorer produces no `LiveError`;
  CM is a no-op on LLMs without a logprobs attribute.

## Description
<!-- Briefly describe what this PR does and why. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Dependency update

## AI Disclosure
<!-- Required. See CONTRIBUTING.md AI Policy. PRs without this section completed will be rejected. -->
- [ ] No AI tools were used to develop this PR
- [ ] AI tools were used, as disclosed below

<!-- If AI tools were used, list the tool(s), how each was used (e.g., drafted implementation, debugged a failing test, wrote docstrings), and which specific files/lines are AI generated or AI assisted. -->

## Checklist
- [ ] I have personally read and can explain every line of this diff, including any AI-generated or AI-suggested code
- [ ] I take full personal responsibility for the correctness, security, and scientific validity of this change
- [ ] I have run this code and the relevant tests locally myself and confirmed the change works as intended, not merely that it looks plausible or that a tool reported success
- [ ] Tests added or updated for all changed behavior
- [ ] Docstrings updated for any new or modified public API
- [ ] Type annotations added for any new or modified functions
- [ ] `ruff check` and `ruff format` pass locally
