### PR TITLE
fix(black_box): return 0.0 match rate for prompts with no sampled responses

### DIFF
--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 import json
 import numpy as np
-import pytest
 from uqlm.black_box import BertScorer, CosineScorer, MatchScorer
 from uqlm.black_box.baseclass.similarity_scorer import SimilarityScorer
 
@@ -52,6 +51,14 @@ def test_exact_match():
     match = MatchScorer()
     match_result = match.evaluate(responses=responses, sampled_responses=sampled_responses)
     assert all([abs(match_result[i] - data["match_result"][i]) < 1e-5 for i in range(len(match_result))])
+
+
+def test_exact_match_empty_candidates():
+    """Empty sampled responses yield 0.0 match rate, not NaN."""
+    match = MatchScorer()
+    result = match.evaluate(responses=["hello"], sampled_responses=[[]])
+    assert result == [0.0]
+    assert not np.isnan(result[0])
 
 
 def test_abstract_base_class():

--- a/uqlm/black_box/match.py
+++ b/uqlm/black_box/match.py
@@ -64,4 +64,8 @@ class MatchScorer(SimilarityScorer):
     @staticmethod
     def _compute_score(response: str, candidates: List[str]) -> float:
         """Get mean exact match rate between response and set of candidates"""
+        if not candidates:
+            # No sampled responses for this prompt: no evidence of a match,
+            # and np.mean([]) would leak NaN into the aggregated scores.
+            return 0.0
         return np.mean([1 if response == c else 0 for c in candidates])


### PR DESCRIPTION
## Description

`MatchScorer._compute_score` returned `np.mean` of an empty list when a prompt had zero sampled responses — NumPy's "mean of empty slice" NaN, which silently leaks into the aggregated UQ scores. This happens on the public `BlackBoxUQ.score(responses=..., sampled_responses=...)` path whenever a prompt's candidate list is empty (e.g. a failed generation that left no samples). Downstream, one NaN poisons means and plots with no error.

No candidates means no observed match: the exact-match rate for that prompt is 0.0, mirroring the repo's existing guard against NaN logprob leakage in white_box (#418).

The same empty-mean pattern exists in `CosineScorer.evaluate` — noted as a follow-up rather than expanding this diff.

## Type of Change
- [x] Bug fix

## AI Disclosure

- [ ] No AI tools were used to develop this PR
- [x] AI tools were used, as disclosed below

AI-assisted development: the root-cause analysis and the regression test were drafted with AI assistance and then reviewed, executed locally, and validated by the human contributor. Files: `uqlm/black_box/match.py` (guard in `_compute_score`), `tests/test_similarity.py` (`test_exact_match_empty_candidates` + removal of an unused `pytest` import).

## Checklist
- [x] I have personally read and can explain every line of this diff, including any AI-generated or AI-suggested code
- [x] I take full personal responsibility for the correctness, security, and scientific validity of this change
- [x] I have run this code and the relevant tests locally myself and confirmed the change works as intended, not merely that it looks plausible or that a tool reported success
- [x] Tests added or updated for all changed behavior
- [x] Docstrings updated for any new or modified public API
- [x] Type annotations added for any new or modified functions
- [x] `ruff check` and `ruff format` pass locally

Local verification: `tests/test_similarity.py -k exact_match` 2 passed (new regression fails on develop with NaN, passes with the guard); ruff 0.9.7 check + format clean on both changed files.