### PR TITLE
fix: stop SemanticEntropy.score() from mutating prompts_in_nli config

### DIFF
--- a/tests/test_semanticentropy.py
+++ b/tests/test_semanticentropy.py
@@ -58,3 +58,20 @@ async def test_semanticentropy(monkeypatch):
         assert all([abs(se_results.data["discrete_entropy_values"][i] - data["entropy_values"][i]) < 1e-5 for i in range(len(PROMPTS))])
         assert all([abs(se_results.data["discrete_confidence_scores"][i] - data["confidence_scores"][i]) < 1e-5 for i in range(len(PROMPTS))])
         assert se_results.metadata == metadata
+
+
+def test_score_without_prompts_keeps_prompts_in_nli_enabled():
+    """A call without prompts must not permanently disable prompt-conditioned NLI."""
+    se_object = SemanticEntropy(llm=mock_object, use_best=False, device="cpu")
+    assert se_object.prompts_in_nli is True
+
+    # No prompts on this call: NLI inputs legitimately omit the prompt...
+    se_object.score(responses=data["responses"], sampled_responses=data["sampled_responses"])
+
+    # ...but the instance-level configuration must survive for later calls.
+    assert se_object.prompts_in_nli is True
+
+    # A subsequent call WITH prompts still conditions NLI inputs on them and
+    # leaves the flag untouched.
+    se_object.score(prompts=data["prompts"], responses=data["responses"], sampled_responses=data["sampled_responses"])
+    assert se_object.prompts_in_nli is True

--- a/uqlm/scorers/shortform/entropy.py
+++ b/uqlm/scorers/shortform/entropy.py
@@ -197,8 +197,11 @@ class SemanticEntropy(ShortFormUQ):
         UQResult
             UQResult, containing data (responses, sampled responses, and semantic entropy scores) and metadata
         """
-        if self.prompts_in_nli and not prompts:
-            self.prompts_in_nli = False
+        # Whether NLI inputs include the prompt for *this* call. Deliberately
+        # computed locally instead of written back to ``self.prompts_in_nli``:
+        # a single call without prompts must not permanently disable
+        # prompt-conditioned clustering for later calls that do provide them.
+        prompts_in_nli = self.prompts_in_nli and bool(prompts)
         self.prompts = prompts if prompts else self.prompts
         self.responses = responses
         self.sampled_responses = sampled_responses
@@ -219,7 +222,7 @@ class SemanticEntropy(ShortFormUQ):
         def _process_i(i):
             candidates = [str(self.responses[i])] + [str(x) for x in self.sampled_responses[i]]
             candidate_logprobs = [self.logprobs[i]] + self.multiple_logprobs[i] if (self.logprobs and self.multiple_logprobs) else None
-            tmp = self._semantic_entropy_process(candidates=candidates, i=i, logprobs_results=candidate_logprobs, best_response_selection=self.best_response_selection)
+            tmp = self._semantic_entropy_process(candidates=candidates, i=i, logprobs_results=candidate_logprobs, best_response_selection=self.best_response_selection, prompts_in_nli=prompts_in_nli)
             best_responses[i], discrete_semantic_entropy[i], tokenprob_semantic_entropy[i], num_semantic_sets[i] = tmp
 
         if self.progress_bar:
@@ -249,7 +252,7 @@ class SemanticEntropy(ShortFormUQ):
         self.progress_bar = None  # if re-run ensure the same progress object is not used
         return UQResult(result)
 
-    def _semantic_entropy_process(self, candidates: List[str], i: int = None, logprobs_results: List[List[Dict[str, Any]]] = None, best_response_selection: str = "discrete") -> Any:
+    def _semantic_entropy_process(self, candidates: List[str], i: int = None, logprobs_results: List[List[Dict[str, Any]]] = None, best_response_selection: str = "discrete", prompts_in_nli: bool = True) -> Any:
         """
         Executes complete process for semantic entropy and returns best response, SE score, and dictionary
         of NLI scores for response pairs
@@ -261,7 +264,7 @@ class SemanticEntropy(ShortFormUQ):
         tokenprob_response_probabilities, response_probabilities = compute_response_probabilities(logprobs_results=logprobs_results, num_responses=len(candidates), length_normalize=self.length_normalize)
 
         # Compute Clusters and NLI scores``
-        tmp = self.prompts[i] if self.prompts_in_nli else None
+        tmp = self.prompts[i] if prompts_in_nli else None
         best_response, clustered_responses, cluster_probabilities, cluster_indices = self.clusterer.evaluate(responses=candidates, prompt=tmp, response_probabilities=response_probabilities)
         num_semantic_sets = len(cluster_probabilities)
 


### PR DESCRIPTION
## Description

Fixes #456

`SemanticEntropy.score()` wrote a per-call decision back to instance configuration:

```python
if self.prompts_in_nli and not prompts:
    self.prompts_in_nli = False
```

One call without `prompts` therefore permanently disabled prompt-conditioned NLI: every later call **with** prompts silently ran NLI without prompt context — different clustering inputs, potentially different scores, no warning. The existing suite already exercises the poisoning path (`test_semanticentropy.py` calls `score()` without prompts), so later prompt-conditioned reuse of such an instance is affected.

The effective flag is now computed locally per call and threaded into `_semantic_entropy_process`; `self.prompts_in_nli` is never mutated.

## Type of Change
- [x] Bug fix

## AI Disclosure

- [ ] No AI tools were used to develop this PR
- [x] AI tools were used, as disclosed below

AI-assisted development: root-cause analysis, fix, and regression test were drafted with AI assistance and then reviewed, executed locally, and validated by the human contributor. Files: `uqlm/scorers/shortform/entropy.py`, `tests/test_semanticentropy.py`.

## Checklist
- [x] I have personally read and can explain every line of this diff, including any AI-generated or AI-suggested code
- [x] I take full personal responsibility for the correctness, security, and scientific validity of this change
- [x] I have run this code and the relevant tests locally myself and confirmed the change works as intended, not merely that it looks plausible or that a tool reported success
- [x] Tests added or updated for all changed behavior
- [x] Docstrings updated for any new or modified public API
- [x] Type annotations added for any new or modified functions
- [x] `ruff check` and `ruff format` pass locally

Local verification: `tests/test_semanticentropy.py` 2 passed (new regression `test_score_without_prompts_keeps_prompts_in_nli_enabled` fails on `develop` — flag flips to False after the prompt-less call — and passes with the local-flag fix); related suites `test_functional_entropy.py` + `test_entropy_utils.py` + `test_semanticdensity.py` + `test_blackboxuq.py` 19 passed; ruff check + format clean on both changed files.
