### PR TITLE
fix(panel): keep one failed judge from poisoning panel aggregates

### DIFF
--- a/tests/test_llmpanel.py
+++ b/tests/test_llmpanel.py
@@ -273,3 +273,32 @@ async def test_llmpanel_without_explanations(monkeypatch, mock_judges, mock_llm)
     # Ensure no explanation columns are present
     assert "judge_1_explanation" not in result.data
     assert "judge_2_explanation" not in result.data
+
+
+@pytest.mark.asyncio
+async def test_panel_aggregates_exclude_unparseable_judge_scores(monkeypatch, mock_judges, mock_llm, recwarn):
+    """One judge exhausting retries must not poison the whole panel's statistics."""
+    import numpy as np
+
+    PROMPTS = data["prompts"][:2]
+    RESPONSES = data["responses"][:2]
+    quantifier = LLMPanel(judges=mock_judges, llm=mock_llm)
+
+    async def judge_one(*args, **kwargs):
+        return {"scores": [0.8, 0.9]}
+
+    async def judge_two(*args, **kwargs):
+        # Prompt 0: retries exhausted -> NaN stays in the scores list.
+        return {"scores": [float("nan"), 0.7]}
+
+    monkeypatch.setattr(quantifier.judges[0], "judge_responses", judge_one)
+    monkeypatch.setattr(quantifier.judges[1], "judge_responses", judge_two)
+
+    result = await quantifier.score(prompts=PROMPTS, responses=RESPONSES)
+
+    assert result.data["avg"][0] == pytest.approx(0.8)
+    assert result.data["max"][0] == pytest.approx(0.8)
+    assert result.data["min"][0] == pytest.approx(0.8)
+    assert not np.isnan(result.data["median"][0])
+    assert result.data["avg"][1] == pytest.approx((0.9 + 0.7) / 2)
+    assert any("could not be parsed" in str(w.message) for w in recwarn.list if issubclass(w.category, UserWarning))

--- a/uqlm/scorers/shortform/panel.py
+++ b/uqlm/scorers/shortform/panel.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
+import warnings
+
 import numpy as np
 from typing import List, Optional, Union
 from langchain_core.language_models.chat_models import BaseChatModel
@@ -165,7 +167,15 @@ class LLMPanel(ShortFormUQ):
 
             judge_count += 1
 
-        scores_dict = {"avg": [np.mean(scores) for scores in zip(*scores_lists)], "max": [np.max(scores) for scores in zip(*scores_lists)], "min": [np.min(scores) for scores in zip(*scores_lists)], "median": [np.median(scores) for scores in zip(*scores_lists)]}
+        # After a judge exhausts its retries, unparseable responses remain NaN.
+        # Aggregate with NaN-aware reductions so one failed judge doesn't poison
+        # every panel statistic, and surface which prompts were affected
+        # instead of silently emitting NaN confidences.
+        per_prompt_scores = list(zip(*scores_lists)) if scores_lists else []
+        unscorable_prompts = [i for i, scores in enumerate(per_prompt_scores) if any(score is None or (isinstance(score, float) and np.isnan(score)) for score in scores)]
+        if unscorable_prompts:
+            warnings.warn(f"Judge scores could not be parsed for {len(unscorable_prompts)} prompt(s) (indices: {unscorable_prompts[:10]}); panel aggregates exclude those judge scores. Inspect the per-judge score columns to identify the failing judge.")
+        scores_dict = {"avg": [np.nanmean(scores) for scores in per_prompt_scores], "max": [np.nanmax(scores) for scores in per_prompt_scores], "min": [np.nanmin(scores) for scores in per_prompt_scores], "median": [np.nanmedian(scores) for scores in per_prompt_scores]}
         data.update(scores_dict)
         result = {"data": data, "metadata": {"num_judges": len(self.judges), "temperature": None if not self.llm else self.llm.temperature}}
 


### PR DESCRIPTION
## Description

Fixes #458

When an `LLMJudge` exhausts its retries, its unparseable responses stay NaN in the scores list. `LLMPanel.score()` aggregated with plain `np.mean/max/min/median`, so a single failed judge turned **every** panel statistic for that prompt into NaN — silently, while the run reported success.

Panel aggregation now uses NaN-aware reductions (`np.nanmean/nanmax/nanmin/nanmedian`) so the panel's redundancy actually helps when one judge fails, and emits a `UserWarning` naming the affected prompt indices; the per-judge score columns already present in the result data make the failing judge identifiable.

Prompts where every judge scored normally are numerically unchanged (NaN-aware reductions equal plain reductions on finite inputs).

## Type of Change
- [x] Bug fix

## AI Disclosure

- [ ] No AI tools were used to develop this PR
- [x] AI tools were used, as disclosed below

AI-assisted development: root-cause analysis, fix, and regression test were drafted with AI assistance and then reviewed, executed locally, and validated by the human contributor. Files: `uqlm/scorers/shortform/panel.py`, `tests/test_llmpanel.py`.

## Checklist
- [x] I have personally read and can explain every line of this diff, including any AI-generated or AI-suggested code
- [x] I take full personal responsibility for the correctness, security, and scientific validity of this change
- [x] I have run this code and the relevant tests locally myself and confirmed the change works as intended, not merely that it looks plausible or that a tool reported success
- [x] Tests added or updated for all changed behavior
- [x] Docstrings updated for any new or modified public API
- [x] Type annotations added for any new or modified functions
- [x] `ruff check` and `ruff format` pass locally

Local verification: new regression `test_panel_aggregates_exclude_unparseable_judge_scores` fails on `develop` (avg/max/min/median all NaN for prompt 0) and passes with this change (aggregates exclude the failed judge's score, warning emitted); full `tests/test_llmpanel.py` 13/13 pass; ruff check + format clean on both changed files.
