### PR TITLE
fix(longform): surface NLI retry exhaustion and keep it out of response aggregates

### DIFF
--- a/tests/test_entailment_classifier.py
+++ b/tests/test_entailment_classifier.py
@@ -243,6 +243,16 @@ class TestEntailmentClassifier(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result["scores"], [1.0])
         self.assertEqual(result["judge_responses"], ["Yes"])
 
+    async def test_judge_entailment_warns_when_retries_exhausted(self):
+        """Regression: unparseable judge responses that survive every retry stay NaN
+        silently; the exhaustion must be surfaced before it reaches aggregation."""
+        self.mock_llm.ainvoke.return_value = AIMessage(content="Maybe, it's unclear")
+
+        with self.assertWarns(UserWarning):
+            result = await self.classifier.judge_entailment(premises=["The dog is barking."], hypotheses=["The animal makes noise."], retries=1)
+
+        self.assertTrue(np.isnan(result["scores"][0]))
+
     def test_format_result_arrays_accepts_nan(self):
         """Regression: the entailment matrix used dtype=int, which cannot hold the NaN left by
         pairs whose extraction failed after all retries."""

--- a/tests/test_longformuq_parent.py
+++ b/tests/test_longformuq_parent.py
@@ -14,6 +14,7 @@
 
 import pytest
 from unittest.mock import MagicMock, patch, AsyncMock
+import numpy as np
 from rich.progress import Progress
 
 from langchain_core.language_models.chat_models import BaseChatModel
@@ -228,6 +229,16 @@ class TestLongFormUQ:
 
         # Check the result
         assert result == [0.6, 0.9]
+
+    def test_aggregate_scores_exclude_nan_claims(self, uq_default):
+        """Regression: a claim whose NLI judge response stayed NaN after retries
+        must not poison the whole response-level score."""
+        claim_scores = [[0.8, np.nan], [0.9, 0.5]]
+
+        assert uq_default._aggregate_scores(claim_scores) == [0.8, 0.7]
+
+        uq_default.aggregation = "min"
+        assert uq_default._aggregate_scores(claim_scores) == [0.8, 0.5]
 
     def test_display_decomposition_header(self, uq_default):
         """Test _display_decomposition_header method."""

--- a/uqlm/nli/entailment.py
+++ b/uqlm/nli/entailment.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import math
+import warnings
 from typing import Any, Dict, Optional, List, Tuple
 
 import asyncio
@@ -104,6 +105,13 @@ class EntailmentClassifier:
             # Exit if no more failures
             if len(score_failures) == 0:
                 break
+
+        # After retries are exhausted, unparseable judge responses remain NaN.
+        # Surface the residue instead of letting it flow silently into claim
+        # matrices and response-level aggregates.
+        residual_failures = df[pd.isna(df.scores)]
+        if len(residual_failures) > 0:
+            warnings.warn(f"Judge scores could not be parsed for {len(residual_failures)} prompt(s) (indices: {list(residual_failures.index)[:10]}) after {retries} retries; those scores remain NaN and will propagate through downstream aggregation.")
         return {col: list(df[col]) for col in df.columns}
 
     async def evaluate_claim_entailment(self, response_sets: List[List[str]], claim_sets: List[List[str]], retries: int = 5, progress_bar: Optional[Progress] = None) -> List[np.ndarray]:

--- a/uqlm/scorers/longform/baseclass/uncertainty.py
+++ b/uqlm/scorers/longform/baseclass/uncertainty.py
@@ -175,10 +175,13 @@ class LongFormUQ(UncertaintyQuantifier):
 
     def _aggregate_scores(self, claim_scores: List[List[float]]) -> List[float]:
         """Aggregate claim scores to response level scores"""
+        # When the NLI judge exhausts its retries, unparseable responses remain
+        # NaN in the claim scores. Aggregate with NaN-aware reductions so one
+        # failed judge response doesn't poison the whole response-level score.
         if self.aggregation == "mean":
-            return [np.mean(cs) for cs in claim_scores]
+            return [np.nanmean(cs) for cs in claim_scores]
         elif self.aggregation == "min":
-            return [np.min(cs) for cs in claim_scores]
+            return [np.nanmin(cs) for cs in claim_scores]
 
     def _display_decomposition_header(self, show_progress_bars: bool) -> None:
         """Displays decomposition header"""


### PR DESCRIPTION
## Description

`EntailmentClassifier.judge_entailment` retries unparseable judge responses, but when every retry fails, the residual NaN scores are carried **silently** into the entailment matrices — `_format_result_arrays` already carries them as float NaN — and then into `LongFormUQ._aggregate_scores`, whose plain `np.mean` / `np.min` turn one failed judge response into a poisoned NaN response-level score, with nothing in the output indicating why.

This is the longform-side twin of the panel issue fixed in #459, and the same failure shape: a judge that emitted nothing usable degrades the final score without a trace.

**Fix.** Mirror the #459 approach:

1. `judge_entailment` now emits a `UserWarning` after the retry loop if any prompts' scores could not be parsed, naming the count and the first ten failing indices, so the exhaustion is visible at the point where it happens.
2. `_aggregate_scores` aggregates with NaN-aware reductions (`np.nanmean` / `np.nanmin`), so a claim whose judge score never parsed is excluded from its response-level aggregate instead of poisoning it — consistent with how `LLMPanel.score()` already treats exhausted judge scores.

All-NaN claim lists still yield NaN (with numpy's own RuntimeWarning), which keeps a fully unjudgeable response distinguishable from a clean one.

## Test

- [x] `test_judge_entailment_warns_when_retries_exhausted` — a judge that returns unparseable text across all retries must emit `UserWarning` and leave the NaN score in the result (pre-fix: no warning).
- [x] `test_aggregate_scores_exclude_nan_claims` — `mean` and `min` aggregation must exclude NaN claims instead of returning NaN for the whole response (pre-fix: `[nan, ...]`).
- [x] Full `tests/test_entailment_classifier.py` + `tests/test_longformuq_parent.py`: 29 passed.
- [x] `ruff check uqlm/` and `ruff format --check uqlm/` clean (CI gates).

## Diff scope

2 source files (+15/−2), 2 test files (+21/−0). No numeric behavior changes for NaN-free inputs.

## AI Disclosure

AI-assisted implementation and regression tests; the failure-chain analysis (retry exhaustion → NaN matrices → plain-mean poisoning) and the final diff were human-reviewed before submission. Disclosure consistent with repository guidelines.
