### PR TITLE
fix(white_box): average monte carlo probability over usable logprob sets

### DIFF
--- a/tests/test_sampled_logprobs.py
+++ b/tests/test_sampled_logprobs.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 from unittest.mock import MagicMock, patch
 from uqlm.white_box.sampled_logprobs import SampledLogprobsScorer, SAMPLED_LOGPROBS_SCORER_NAMES
@@ -60,6 +61,37 @@ def test_monte_carlo_probability(scorer):
         result = scorer.monte_carlo_probability(responses=responses, logprobs_results=logprobs_results, sampled_logprobs_results=sampled_logprobs_results)
         assert isinstance(result, list)
         assert len(result) == len(responses)
+
+
+def test_monte_carlo_probability_excludes_logprob_sets_without_logprobs(scorer):
+    """One logprob set missing its payload must not destroy the estimate from the rest."""
+    responses = ["response1", "response2"]
+    logprobs_results = [[{"logprob": -0.1}], [{"logprob": -0.2}]]
+    sampled_logprobs_results = [[[{"logprob": -0.3}], None, [{"logprob": -0.5}]], [[{"logprob": -0.4}], [{"logprob": -0.6}]]]
+
+    result = scorer.monte_carlo_probability(responses=responses, logprobs_results=logprobs_results, sampled_logprobs_results=sampled_logprobs_results)
+
+    assert not np.isnan(result[0])
+    assert np.isclose(result[0], np.mean([np.exp(-0.1), np.exp(-0.3), np.exp(-0.5)]))
+    assert np.isclose(result[1], np.mean([np.exp(-0.2), np.exp(-0.4), np.exp(-0.6)]))
+
+
+def test_monte_carlo_probability_warns_when_logprob_sets_are_unusable(scorer):
+    """The reduced effective sample count must be surfaced, not silent."""
+    responses = ["response1", "response2"]
+    logprobs_results = [[{"logprob": -0.1}], [{"logprob": -0.2}]]
+    sampled_logprobs_results = [[[{"logprob": -0.3}], None, [{"logprob": -0.5}]], [[{"logprob": -0.4}], [{"logprob": -0.6}]]]
+
+    with pytest.warns(UserWarning, match=r"Logprobs were unavailable for 1 of 7 logprob sets \(responses: \[0\]\)"):
+        scorer.monte_carlo_probability(responses=responses, logprobs_results=logprobs_results, sampled_logprobs_results=sampled_logprobs_results)
+
+
+def test_monte_carlo_probability_returns_nan_when_all_sets_unusable(scorer):
+    """A response with no usable logprobs stays NaN rather than getting a fabricated value."""
+    with pytest.warns(UserWarning, match=r"Logprobs were unavailable for 2 of 2 logprob sets"):
+        result = scorer.monte_carlo_probability(responses=["response1"], logprobs_results=[None], sampled_logprobs_results=[[None]])
+
+    assert np.isnan(result[0])
 
 
 def test_compute_consistency_confidence(scorer):

--- a/uqlm/white_box/sampled_logprobs.py
+++ b/uqlm/white_box/sampled_logprobs.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
+import warnings
+
 from typing import List, Dict, Any, Optional
 import numpy as np
 from rich.progress import Progress
@@ -113,11 +115,24 @@ class SampledLogprobsScorer(LogprobsScorer):
     def monte_carlo_probability(self, responses: List[str], logprobs_results: List[List[Dict[str, Any]]], sampled_logprobs_results: List[List[List[Dict[str, Any]]]]) -> List[float]:
         monte_carlo_scores = []
         score_fn = self._norm_prob if self.length_normalize else self._seq_prob
+        unusable_sets = 0
+        total_sets = 0
+        affected_responses = []
         for i in range(len(responses)):
             all_logprobs_response_i = [logprobs_results[i]] + sampled_logprobs_results[i]
             all_sampled_sequence_probs_response_i = self._compute_single_generation_scores(all_logprobs_response_i, score_fn)
-            monte_carlo_sequence_prob_i = np.mean(all_sampled_sequence_probs_response_i)
+            total_sets += len(all_sampled_sequence_probs_response_i)
+            unusable = sum(1 for prob in all_sampled_sequence_probs_response_i if np.isnan(prob))
+            if unusable:
+                unusable_sets += unusable
+                affected_responses.append(i)
+            # A logprob set whose payload is missing is NaN by contract. Aggregate
+            # over the usable sets so one dropped payload doesn't destroy the
+            # estimate built from the remaining samples.
+            monte_carlo_sequence_prob_i = np.nanmean(all_sampled_sequence_probs_response_i)
             monte_carlo_scores.append(monte_carlo_sequence_prob_i)
+        if unusable_sets:
+            warnings.warn(f"Logprobs were unavailable for {unusable_sets} of {total_sets} logprob sets (responses: {affected_responses[:10]}); Monte Carlo probability for those responses is averaged over their usable sets only, so their effective sample count is reduced.")
         return monte_carlo_scores
 
     def compute_semantic_negentropy(self, responses: List[str], prompts: List[str], sampled_responses: List[List[str]], logprobs_results: List[List[Dict[str, Any]]], sampled_logprobs_results: List[List[List[Dict[str, Any]]]], progress_bar: Optional[Progress] = None) -> List[float]:


### PR DESCRIPTION
## Description

`LogprobsScorer._compute_single_generation_scores` returns `np.nan` for a logprob set whose payload is missing, and that shape does occur in normal use: when every `top_logprobs` invocation fails, `ResponseGenerator` returns `{"logprobs": [None] * count, "responses": [FAILED_RESPONSE] * count}` (`uqlm/utils/response_generator.py:259-260`), and the entropy/density base classes default `sampled_logprobs_results` to `[[None] * ...]` (`uqlm/code/entropy.py:86`).

`SampledLogprobsScorer.monte_carlo_probability` then averaged those per-sample sequence probabilities with a plain `np.mean`. One unusable sampled set therefore turned that response's entire Monte Carlo estimate into NaN even though the other samples were perfectly good, and nothing in the output or in the emitted warnings said why — the user loses a multi-sample estimate and gets no indication of which sample was dropped or how many remain.

This is the third aggregation site of the same failure shape as #459 and #462: the per-set NaN contract in `logprobs_scorer.py:48` is where the loss originates in all of them.

**Fix.** Mirror the approach those two took:

1. Aggregate with `np.nanmean`, so the estimate uses the usable sets instead of being destroyed by one missing payload.
2. Emit a `UserWarning` after the loop naming how many logprob sets were unavailable out of how many and which response indices are affected, so the reduced effective sample count is visible rather than something you can only infer from the numbers.

A response whose sets are all unusable still yields NaN (with numpy's own `Mean of empty slice` RuntimeWarning), which keeps a fully unscorable response distinguishable from a clean one. Inputs with no missing sets are unchanged — `np.nanmean` equals `np.mean` there.

## Type of Change
- [x] Bug fix

## Test

Three regression tests added to `tests/test_sampled_logprobs.py`. They call `monte_carlo_probability` directly on hand-built logprob structures, so no model or API access is needed. **All three fail on `origin/develop` and pass after the change:**

- `test_monte_carlo_probability_excludes_logprob_sets_without_logprobs` — one `None` set among four must leave the estimate at the mean of the three usable ones (pre-fix: `nan`)
- `test_monte_carlo_probability_warns_when_logprob_sets_are_unusable` — must warn `Logprobs were unavailable for 1 of 7 logprob sets (responses: [0])` (pre-fix: no warning at all)
- `test_monte_carlo_probability_returns_nan_when_all_sets_unusable` — an all-unusable response must stay NaN rather than get a fabricated value (pre-fix: no warning)

```
# source reverted to origin/develop, new tests only
3 failed, 2 passed

# with the fix, tests/test_sampled_logprobs.py -k "monte_carlo or initialization or evaluate_with_mocked_scorers"
9 passed, 4 deselected
```

The remaining four tests in that file (semantic entropy / semantic density) load `microsoft/deberta-large-mnli` and did not finish on this machine within a reasonable window, so they are reported as unverified locally rather than as passing. They exercise different methods.

Consumer suites, unaffected:

```
tests/test_whiteboxuq.py tests/test_llmpanel.py tests/test_logprobs_scorer.py tests/test_top_logprobs.py
33 passed
```

Pinned toolchain (`ruff` `v0.9.7` from `.pre-commit-config.yaml`, matching the `linting.yml` gates):

```
ruff check uqlm/            -> All checks passed!
ruff format --check uqlm/   -> 91 files already formatted
```

## Diff scope

2 files, +48/−1: one source file (`uqlm/white_box/sampled_logprobs.py`, +17/−1) and one test file (+32/−0). No public signature changes, no new dependencies, no numeric behavior change for inputs that have no missing logprob sets.

## AI Disclosure
- [x] AI tools were used, as disclosed below

An agent (Qoder, on the account owner's machine) located this defect by comparing this aggregation site against the two the maintainers already fixed in #459 and #462, and drafted both the implementation and the regression tests. Every command output quoted above was produced by a real local run on that machine, including the pre-fix run against reverted source. The agent additionally checked that `_compute_single_generation_scores`'s NaN contract, `response_generator.py:259`, and `entropy.py:86` make the missing-payload case reachable, and searched open and closed issues and PRs for prior art. The account owner reviewed the change and this description, authorized this agent to push the branch and open this PR on their behalf, and takes responsibility for the correctness and scientific validity of the diff.

## Checklist
- [x] I have personally read and can explain every line of this diff, including any AI-generated or AI-suggested code
- [x] I take full personal responsibility for the correctness, security, and scientific validity of this change
- [x] I have run this code and the relevant tests locally myself and confirmed the change works as intended, not merely that it looks plausible or that a tool reported success
- [x] Tests added or updated for all changed behavior
- [x] Docstrings updated for any new or modified public API (no public API signature changed)
- [x] Type annotations added for any new or modified functions (signature unchanged)
- [x] `ruff check` and `ruff format` pass locally
