### PR TITLE
Parse continuous judge answers as a numeric token, not concatenated digits

### DIFF
--- a/tests/test_llmjudge.py
+++ b/tests/test_llmjudge.py
@@ -86,6 +86,30 @@ def test_extract_single_answer_continuous(mock_llm, test_data):
     assert judge._extract_single_answer("0") == 0.0
 
 
+def test_continuous_decimal_answers_keep_their_scale(mock_llm):
+    """Regression for #468: decimal-bearing judge answers must keep their own scale.
+
+    The parser concatenated every digit of the response, so a 0-1 style answer
+    like "0.8" was read as "08" and silently divided down to 0.08, while a
+    decimal-bearing 0-100 answer like "85.5" collapsed to "855" and fell to NaN.
+    """
+    judge = LLMJudge(llm=mock_llm, scoring_template="continuous")
+    # 0-100 integer answers are unchanged
+    assert judge._extract_score_from_text("99") == 0.99
+    assert judge._extract_score_from_text("85") == 0.85
+    assert judge._extract_score_from_text("100") == 1.0
+    assert judge._extract_score_from_text("8") == 0.08
+    assert judge._extract_score_from_text("4") == 0.04
+    # explicit 0-1 decimal answers keep their own scale
+    assert judge._extract_score_from_text("0.8") == 0.8
+    assert judge._extract_score_from_text("0.5") == 0.5
+    assert judge._extract_score_from_text("1.0") == 1.0
+    assert judge._extract_score_from_text("0.9") == 0.9
+    assert judge._extract_score_from_text("0.05") == 0.05
+    # decimal-bearing 0-100 answers
+    assert judge._extract_score_from_text("85.5") == 0.855
+
+
 def test_extract_single_answer_true_false(mock_llm, test_data):
     """Test true/false score extraction"""
     judge = LLMJudge(llm=mock_llm, scoring_template="true_false")

--- a/uqlm/judges/judge.py
+++ b/uqlm/judges/judge.py
@@ -15,6 +15,7 @@
 
 import contextlib
 import io
+import re
 
 import numpy as np
 import pandas as pd
@@ -210,10 +211,15 @@ class LLMJudge(ResponseGenerator):
         Used for both structured responses and backward compatibility.
         """
         if self.scoring_template == "continuous":
-            # Extract all digits and decimal points
-            score = "".join(c for c in response if c.isdigit())
-            if len(score) > 0:
-                score_val = float(score)
+            # Parse the first numeric token instead of concatenating digits: concatenation destroys the
+            # decimal point, so "0.8" was indistinguishable from "8" (silently mis-scaled to 0.08) and
+            # "85.5" collapsed to "855" (NaN). A decimal token <= 1.0 is an explicit 0-1 answer and keeps
+            # its own scale; integer answers stay on the 0-100 scale the template instructs.
+            match = re.search(r"\d+(?:\.\d+)?", response)
+            if match:
+                score_val = float(match.group())
+                if "." in match.group() and 0.0 <= score_val <= 1.0:
+                    return score_val  # already normalized
                 if 0.0 <= score_val <= 100.0:
                     return score_val / 100.0  # normalize
             return np.nan


### PR DESCRIPTION
## Root Cause

`LLMJudge._extract_score_from_text()` with `scoring_template="continuous"` concatenated **every digit character** of the judge response and read the result as a 0-100 integer. A judge that answers on a 0-1 scale (a common instruction-following deviation, since the quantity being estimated is itself 0-1) was silently mis-scaled: `"0.8"` was read as `"08"` and divided down to **0.08**, `"0.5"` -> 0.05, `"1.0"` -> 0.1. A decimal-bearing 0-100 answer collapsed instead: `"85.5"` -> `"855"` -> NaN.

Because a wrong parse is a *valid float*, it never entered the NaN retry loop in `judge_responses()` — the mis-scaled score flowed into panel means and uncertainty thresholds with no warning. The categorical templates in the same method are deliberately robust to verbose judges (keyword scanning); the continuous path was the one format that degraded silently. Measured against current `main`:

| judge response | parsed before | intended |
|---|---|---|
| `"0.8"` | 0.08 | 0.8 |
| `"0.5"` | 0.05 | 0.5 |
| `"1.0"` | 0.1 | 1.0 |
| `"85.5"` | NaN | 0.855 |
| `"99"` / `"85"` / `"8"` / `"4"` / `"0.05"` | unchanged | — |

The `"already normalized"` branch removed in `e26f51f` was dead on arrival (any value <= 1.0 entered the `<= 100.0` branch first and was divided by 100 anyway), so the normalization ambiguity was never actually resolved.

## Fix

Parse the **first numeric token** (`re.search(r"\d+(?:\.\d+)?", response)`) instead of concatenating digits. A token containing a decimal point with value <= 1.0 is an explicit 0-1 answer and keeps its own scale; everything else stays on the instructed 0-100 scale, so integer answers (`"99"`, `"85"`, `"8"`, `"4"`) behave exactly as before.

## Test

- `test_continuous_decimal_answers_keep_their_scale` (tests/test_llmjudge.py): fails on unpatched `main` (`"0.8"` -> 0.08, `"85.5"` -> NaN), passes with the fix; also pins the unchanged integer behavior. Full `tests/test_llmjudge.py`: 17 passed (16 baseline + 1).

## Diff scope

2 files, +34/-4 (`uqlm/judges/judge.py`, `tests/test_llmjudge.py`).

## AI disclosure (per CONTRIBUTING.md AI Policy)

AI assistance was used in developing this change: an AI coding assistant helped draft the regex-based extraction and the regression test. I reviewed the change against the judge parsing logic, verified the 0-100 integer behavior is unchanged case-by-case, and ran the full test file locally (17 passed). This PR description was written from the verified test results. I understand the code submitted and take responsibility for it.
